### PR TITLE
Avoid capitalizing project name in customer email template

### DIFF
--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -19,7 +19,7 @@ const PreviewTemplates: React.FC<PreviewTemplatesProps> = ({
   const [copiedTemplate, setCopiedTemplate] = useState<string | null>(null)
 
   const generateEmailTemplate = () => {
-    const projectName = equipmentData.projectName || '[Project Name]'
+    const projectName = equipmentData.projectName || '[project name]'
     const companyName = equipmentData.companyName || '[Company Name]'
     const contactName = equipmentData.contactName || '[Contact Name]'
     const projectAddress = equipmentData.projectAddress || '[Project Address]'


### PR DESCRIPTION
## Summary
- ensure email template preview uses lowercase placeholder for project name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 20 errors, 5 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acfc7194008321b62ca8f6bac2f074