### PR TITLE
Ensure quotes policy recreated safely

### DIFF
--- a/supabase/migrations/20250820221158_small_desert.sql
+++ b/supabase/migrations/20250820221158_small_desert.sql
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS quotes (
 ALTER TABLE quotes ENABLE ROW LEVEL SECURITY;
 
 -- Create policy for public access
+DROP POLICY IF EXISTS "Allow public access to quotes" ON quotes;
 CREATE POLICY "Allow public access to quotes"
   ON quotes
   FOR ALL


### PR DESCRIPTION
## Summary
- drop existing `Allow public access to quotes` policy before recreating it during migration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 17 errors, 5 warnings)*
- `supabase migration up` *(fails: command not found: supabase)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3a4ad024832193fa7ebe2a0b23f6