### PR TITLE
Align sidebar and main header heights for consistent border

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1759,7 +1759,7 @@ When job is complete clean up debris and return to ${shopLocation}.`
       {/* Sidebar */}
       <div className="w-64 bg-gray-900 border-r-2 border-accent flex flex-col h-screen sticky top-0">
         {/* Logo */}
-        <div className="p-6 border-b-2 border-accent">
+        <div className="px-6 py-4 border-b-2 border-accent">
           <h1 className="text-xl font-bold text-white">OM Quote</h1>
           <p className="text-sm text-white">Quote Generator</p>
         </div>


### PR DESCRIPTION
## Summary
- Align sidebar logo section with main header by adjusting padding to `px-6 py-4`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 17 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68af5c56dd6c8321a76a76c9196503ee