### PR TITLE
Add truck type selection and extraction support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ const App: React.FC = () => {
     deliveryState: '',
     deliveryZip: '',
     serviceType: 'Standard Delivery',
+    truckType: '',
     specialHandling: ''
   })
 
@@ -141,7 +142,7 @@ const App: React.FC = () => {
 
   const handleLoadQuote = (loadedEquipmentData: any, loadedLogisticsData: any) => {
     setEquipmentData(loadedEquipmentData)
-    setLogisticsData(loadedLogisticsData)
+    setLogisticsData({ truckType: '', ...loadedLogisticsData })
   }
 
   const handleApiKeyChange = () => {
@@ -592,6 +593,21 @@ const App: React.FC = () => {
                   <option value="White Glove">White Glove</option>
                   <option value="Inside Delivery">Inside Delivery</option>
                   <option value="Curbside">Curbside</option>
+                </select>
+              </div>
+
+              {/* Truck Type Requested */}
+              <div>
+                <label className="block text-sm font-medium text-white mb-2">Truck Type Requested</label>
+                <select
+                  value={logisticsData.truckType}
+                  onChange={(e) => handleLogisticsChange('truckType', e.target.value)}
+                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                >
+                  <option value="">Select truck type</option>
+                  <option value="Flatbed">Flatbed</option>
+                  <option value="Flatbed with tarp">Flatbed with tarp</option>
+                  <option value="Conestoga">Conestoga</option>
                 </select>
               </div>
 

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -54,6 +54,7 @@ LOGISTICS REQUIREMENTS:
 • Pickup Location: ${pickupAddress}, ${pickupCity}, ${pickupState}
 • Delivery Location: ${deliveryAddress}, ${deliveryCity}, ${deliveryState}
 • Service Type: ${logisticsData.serviceType || 'Standard Delivery'}
+${logisticsData.truckType ? `• Truck Type: ${logisticsData.truckType}` : ''}
 ${logisticsData.specialHandling ? `• Special Handling: ${logisticsData.specialHandling}` : ''}
 
     ${logisticsData.pieces && logisticsData.pieces.length > 0 ? `ITEMS TO TRANSPORT:
@@ -90,6 +91,8 @@ ${contactName}
 ${phone}
 
 Omega Morgan to supply 3-man crew, Gear Truck and Trailer.
+
+${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n\n` : ''}
 
 ${equipmentData.projectDescription ? `PROJECT DESCRIPTION:
 ${equipmentData.projectDescription}

--- a/supabase/functions/ai-extract-project/index.ts
+++ b/supabase/functions/ai-extract-project/index.ts
@@ -49,9 +49,10 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "pickupZip": "string",
     "deliveryAddress": "string",
     "deliveryCity": "string",
-    "deliveryState": "string", 
+    "deliveryState": "string",
     "deliveryZip": "string",
     "serviceType": "string (Standard Delivery, White Glove, Inside Delivery, or Curbside)",
+    "truckType": "string (Flatbed, Flatbed with tarp, Conestoga)",
     "specialHandling": "string"
   }
 }

--- a/supabase/functions/ai-extract-with-storage/index.ts
+++ b/supabase/functions/ai-extract-with-storage/index.ts
@@ -49,9 +49,10 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "pickupZip": "string",
     "deliveryAddress": "string",
     "deliveryCity": "string",
-    "deliveryState": "string", 
+    "deliveryState": "string",
     "deliveryZip": "string",
     "serviceType": "string (Standard Delivery, White Glove, Inside Delivery, or Curbside)",
+    "truckType": "string (Flatbed, Flatbed with tarp, Conestoga)",
     "specialHandling": "string"
   }
 }


### PR DESCRIPTION
## Summary
- add truck type selection to logistics form
- surface selected truck type in preview templates
- teach AI extraction functions about truckType field

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 19 errors, 6 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68bef5f9b89c8321884eb22a5680c257