### PR TITLE
Add truck type dropdown to quote form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,10 @@ import {
   Eye, 
   X, 
   Bot, 
-  Archive, 
-  Plus, 
-  Minus, 
-  Search, 
-  Building, 
+  Archive,
+  Plus,
+  Minus,
+  Building,
   User, 
   Phone, 
   MapPin, 
@@ -25,7 +24,7 @@ import PreviewTemplates from './components/PreviewTemplates'
 import QuoteHistoryModal from './components/QuoteHistoryModal'
 import ApiKeySetup from './components/ApiKeySetup'
 import HubSpotContactSearch from './components/HubSpotContactSearch'
-import { HubSpotService, HubSpotContact } from './services/hubspotService'
+import { HubSpotContact } from './services/hubspotService'
 
 const App: React.FC = () => {
   // State for equipment form
@@ -55,7 +54,7 @@ const App: React.FC = () => {
     deliveryCity: '',
     deliveryState: '',
     deliveryZip: '',
-    serviceType: 'Standard Delivery',
+    truckType: 'LTL (Less Than Truckload)',
     specialHandling: ''
   })
 
@@ -580,18 +579,16 @@ const App: React.FC = () => {
                 </div>
               </div>
 
-              {/* Service Type */}
+              {/* Truck Type */}
               <div>
-                <label className="block text-sm font-medium text-white mb-2">Service Type</label>
+                <label className="block text-sm font-medium text-white mb-2">Truck Type</label>
                 <select
-                  value={logisticsData.serviceType}
-                  onChange={(e) => handleLogisticsChange('serviceType', e.target.value)}
+                  value={logisticsData.truckType}
+                  onChange={(e) => handleLogisticsChange('truckType', e.target.value)}
                   className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
                 >
-                  <option value="Standard Delivery">Standard Delivery</option>
-                  <option value="White Glove">White Glove</option>
-                  <option value="Inside Delivery">Inside Delivery</option>
-                  <option value="Curbside">Curbside</option>
+                  <option value="LTL (Less Than Truckload)">LTL (Less Than Truckload)</option>
+                  <option value="FTL (Full Truckload)">FTL (Full Truckload)</option>
                 </select>
               </div>
 

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -53,7 +53,7 @@ ${projectDescription}
 LOGISTICS REQUIREMENTS:
 • Pickup Location: ${pickupAddress}, ${pickupCity}, ${pickupState}
 • Delivery Location: ${deliveryAddress}, ${deliveryCity}, ${deliveryState}
-• Service Type: ${logisticsData.serviceType || 'Standard Delivery'}
+• Truck Type: ${logisticsData.truckType || 'LTL (Less Than Truckload)'}
 ${logisticsData.specialHandling ? `• Special Handling: ${logisticsData.specialHandling}` : ''}
 
     ${logisticsData.pieces && logisticsData.pieces.length > 0 ? `ITEMS TO TRANSPORT:

--- a/supabase/functions/ai-extract-project/index.ts
+++ b/supabase/functions/ai-extract-project/index.ts
@@ -51,7 +51,7 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "deliveryCity": "string",
     "deliveryState": "string", 
     "deliveryZip": "string",
-    "serviceType": "string (Standard Delivery, White Glove, Inside Delivery, or Curbside)",
+    "truckType": "string (LTL (Less Than Truckload) or FTL (Full Truckload))",
     "specialHandling": "string"
   }
 }

--- a/supabase/functions/ai-extract-with-storage/index.ts
+++ b/supabase/functions/ai-extract-with-storage/index.ts
@@ -51,7 +51,7 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "deliveryCity": "string",
     "deliveryState": "string", 
     "deliveryZip": "string",
-    "serviceType": "string (Standard Delivery, White Glove, Inside Delivery, or Curbside)",
+    "truckType": "string (LTL (Less Than Truckload) or FTL (Full Truckload))",
     "specialHandling": "string"
   }
 }


### PR DESCRIPTION
## Summary
- replace service type with truck type in logistics form
- show selected truck type in quote preview templates
- update extraction prompts to include truckType field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 25 problems (19 errors, 6 warnings))*
- `npx eslint src/App.tsx src/components/PreviewTemplates.tsx supabase/functions/ai-extract-project/index.ts supabase/functions/ai-extract-with-storage/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bef60fafcc8321bad687a7eb109ffb