### PR TITLE
Remove special instruction and handling sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,8 +40,7 @@ const App: React.FC = () => {
     state: '',
     zipCode: '',
     projectDescription: '',
-    additionalDetails: '',
-    specialInstructions: ''
+    additionalDetails: ''
   })
 
   // State for logistics form
@@ -56,8 +55,7 @@ const App: React.FC = () => {
     deliveryState: '',
     deliveryZip: '',
     serviceType: 'Standard Delivery',
-    truckType: '',
-    specialHandling: ''
+    truckType: ''
   })
 
   // Modal states
@@ -396,16 +394,6 @@ const App: React.FC = () => {
                 />
               </div>
 
-              <div>
-                <label className="block text-sm font-medium text-white mb-2">Special Instructions</label>
-                <textarea
-                  value={equipmentData.specialInstructions}
-                  onChange={(e) => handleEquipmentChange('specialInstructions', e.target.value)}
-                  rows={3}
-                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent resize-none text-white"
-                  placeholder="Any special instructions or requirements"
-                />
-              </div>
             </div>
           </div>
 
@@ -611,17 +599,6 @@ const App: React.FC = () => {
                 </select>
               </div>
 
-              {/* Special Handling */}
-              <div>
-                <label className="block text-sm font-medium text-white mb-2">Special Handling</label>
-                <textarea
-                  value={logisticsData.specialHandling}
-                  onChange={(e) => handleLogisticsChange('specialHandling', e.target.value)}
-                  rows={3}
-                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent resize-none text-white"
-                  placeholder="Any special handling requirements"
-                />
-              </div>
             </div>
           </div>
         </div>

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -35,6 +35,7 @@ const PreviewTemplates: React.FC<PreviewTemplatesProps> = ({
     const deliveryCity = logisticsData.deliveryCity || '[Delivery City]'
     const deliveryState = logisticsData.deliveryState || '[Delivery State]'
 
+
     return `Subject: Quote Request - ${projectName}
 
 Dear Omega Morgan Team,
@@ -55,7 +56,6 @@ LOGISTICS REQUIREMENTS:
 • Delivery Location: ${deliveryAddress}, ${deliveryCity}, ${deliveryState}
 • Service Type: ${logisticsData.serviceType || 'Standard Delivery'}
 ${logisticsData.truckType ? `• Truck Type: ${logisticsData.truckType}` : ''}
-${logisticsData.specialHandling ? `• Special Handling: ${logisticsData.specialHandling}` : ''}
 
     ${logisticsData.pieces && logisticsData.pieces.length > 0 ? `ITEMS TO TRANSPORT:
     ${logisticsData.pieces.map((piece: any, index: number) =>
@@ -64,8 +64,6 @@ ${logisticsData.specialHandling ? `• Special Handling: ${logisticsData.special
 
 Please provide a detailed quote including all equipment, labor, and transportation costs. We would appreciate receiving this quote at your earliest convenience.
 
-${equipmentData.specialInstructions ? `SPECIAL INSTRUCTIONS:
-${equipmentData.specialInstructions}` : ''}
 
 Thank you for your time and consideration. I look forward to hearing from you soon.
 
@@ -101,12 +99,6 @@ ${equipmentData.projectDescription}
 ${logisticsData.pieces.map((piece: any) =>
   `• (Qty: ${piece.quantity || 1}) ${piece.description || '[Item Description]'} - ${piece.length || '[L]'}"L x ${piece.width || '[W]'}"W x ${piece.height || '[H]'}"H, ${piece.weight || '[Weight]'} lbs`
 ).join('\n')}
-
-` : ''}${logisticsData.specialHandling ? `SPECIAL HANDLING REQUIREMENTS:
-${logisticsData.specialHandling}
-
-` : ''}${equipmentData.specialInstructions ? `SPECIAL INSTRUCTIONS:
-${equipmentData.specialInstructions}
 
 ` : ''}When job is complete clean up debris and return to [Shop].`
   }

--- a/supabase/functions/ai-extract-project/index.ts
+++ b/supabase/functions/ai-extract-project/index.ts
@@ -38,8 +38,7 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "city": "string",
     "state": "string",
     "zipCode": "string",
-    "projectDescription": "string",
-    "specialInstructions": "string"
+    "projectDescription": "string"
   },
   "logistics": {
     "pieces": [{"description": "string", "quantity": "number", "length": "number", "width": "number", "height": "number", "weight": "number"}],
@@ -52,8 +51,7 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "deliveryState": "string",
     "deliveryZip": "string",
     "serviceType": "string (Standard Delivery, White Glove, Inside Delivery, or Curbside)",
-    "truckType": "string (Flatbed, Flatbed with tarp, Conestoga)",
-    "specialHandling": "string"
+    "truckType": "string (Flatbed, Flatbed with tarp, Conestoga)"
   }
 }
 

--- a/supabase/functions/ai-extract-with-storage/index.ts
+++ b/supabase/functions/ai-extract-with-storage/index.ts
@@ -38,8 +38,7 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "city": "string",
     "state": "string",
     "zipCode": "string",
-    "projectDescription": "string",
-    "specialInstructions": "string"
+    "projectDescription": "string"
   },
   "logistics": {
     "pieces": [{"description": "string", "quantity": "number", "length": "number", "width": "number", "height": "number", "weight": "number"}],
@@ -52,8 +51,7 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "deliveryState": "string",
     "deliveryZip": "string",
     "serviceType": "string (Standard Delivery, White Glove, Inside Delivery, or Curbside)",
-    "truckType": "string (Flatbed, Flatbed with tarp, Conestoga)",
-    "specialHandling": "string"
+    "truckType": "string (Flatbed, Flatbed with tarp, Conestoga)"
   }
 }
 


### PR DESCRIPTION
## Summary
- drop special instruction and handling fields from quote forms and previews
- update AI extraction prompts to exclude special instructions and handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 25 problems (19 errors, 6 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68bef9374fd48321937e3700ae38fc8a