### PR TITLE
refactor: remove project description field

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,6 @@ const App: React.FC = () => {
     city: '',
     state: '',
     zipCode: '',
-    projectDescription: '',
     additionalDetails: ''
   })
 
@@ -131,7 +130,8 @@ const App: React.FC = () => {
 
   const handleAIExtraction = (extractedEquipmentData: any, extractedLogisticsData: any) => {
     if (extractedEquipmentData) {
-      setEquipmentData(prev => ({ ...prev, ...extractedEquipmentData }))
+      const { projectDescription, ...rest } = extractedEquipmentData
+      setEquipmentData(prev => ({ ...prev, ...rest }))
     }
     if (extractedLogisticsData) {
       setLogisticsData(prev => ({ ...prev, ...extractedLogisticsData }))
@@ -355,32 +355,6 @@ const App: React.FC = () => {
                     placeholder="Enter zip code"
                   />
                 </div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-white mb-2">Project Description</label>
-                <select
-                  value={equipmentData.projectDescription}
-                  onChange={(e) => handleEquipmentChange('projectDescription', e.target.value)}
-                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent resize-none text-white"
-                >
-                  <option value="">Select project type</option>
-                  <option value="Heavy Equipment Transport">Heavy Equipment Transport</option>
-                  <option value="Machinery Rigging & Installation">Machinery Rigging & Installation</option>
-                  <option value="Industrial Plant Relocation">Industrial Plant Relocation</option>
-                  <option value="Construction Equipment Moving">Construction Equipment Moving</option>
-                  <option value="Manufacturing Equipment Setup">Manufacturing Equipment Setup</option>
-                  <option value="Warehouse Equipment Installation">Warehouse Equipment Installation</option>
-                  <option value="Medical Equipment Transport">Medical Equipment Transport</option>
-                  <option value="Server Room Equipment Moving">Server Room Equipment Moving</option>
-                  <option value="Laboratory Equipment Relocation">Laboratory Equipment Relocation</option>
-                  <option value="HVAC System Installation">HVAC System Installation</option>
-                  <option value="Generator Installation">Generator Installation</option>
-                  <option value="Transformer Installation">Transformer Installation</option>
-                  <option value="Crane Services">Crane Services</option>
-                  <option value="Millwright Services">Millwright Services</option>
-                  <option value="Custom Project">Custom Project</option>
-                </select>
               </div>
 
               <div>

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -25,7 +25,7 @@ const PreviewTemplates: React.FC<PreviewTemplatesProps> = ({
     const projectAddress = equipmentData.projectAddress || '[Project Address]'
     const city = equipmentData.city || '[City]'
     const state = equipmentData.state || '[State]'
-    const projectDescription = equipmentData.projectDescription || '[Project Description]'
+    const additionalDetails = equipmentData.additionalDetails || ''
     
     const pickupAddress = logisticsData.pickupAddress || projectAddress
     const pickupCity = logisticsData.pickupCity || city
@@ -48,10 +48,7 @@ PROJECT DETAILS:
 • Contact: ${contactName}
 • Project Location: ${projectAddress}, ${city}, ${state}
 
-PROJECT DESCRIPTION:
-${projectDescription}
-
-LOGISTICS REQUIREMENTS:
+${additionalDetails ? `ADDITIONAL DETAILS:\n${additionalDetails}\n\n` : ''}LOGISTICS REQUIREMENTS:
 • Pickup Location: ${pickupAddress}, ${pickupCity}, ${pickupState}
 • Delivery Location: ${deliveryAddress}, ${deliveryCity}, ${deliveryState}
 • Service Type: ${logisticsData.serviceType || 'Standard Delivery'}
@@ -80,7 +77,7 @@ ${equipmentData.phone || '[Phone]'}`
     const state = equipmentData.state || '[State]'
     const contactName = equipmentData.contactName || '[Site Contact]'
     const phone = equipmentData.phone || '[Site Contact Phone Number]'
-    
+
     return `SCOPE OF WORK
 
 Mobilize crew and Omega Morgan equipment to site: ${projectAddress}, ${city}, ${state}
@@ -90,12 +87,7 @@ ${phone}
 
 Omega Morgan to supply 3-man crew, Gear Truck and Trailer.
 
-${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n\n` : ''}
-
-${equipmentData.projectDescription ? `PROJECT DESCRIPTION:
-${equipmentData.projectDescription}
-
-` : ''}${logisticsData.pieces && logisticsData.pieces.length > 0 ? `ITEMS TO HANDLE:
+${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n\n` : ''}${equipmentData.additionalDetails ? `${equipmentData.additionalDetails}\n\n` : ''}${logisticsData.pieces && logisticsData.pieces.length > 0 ? `ITEMS TO HANDLE:
 ${logisticsData.pieces.map((piece: any) =>
   `• (Qty: ${piece.quantity || 1}) ${piece.description || '[Item Description]'} - ${piece.length || '[L]'}"L x ${piece.width || '[W]'}"W x ${piece.height || '[H]'}"H, ${piece.weight || '[Weight]'} lbs`
 ).join('\n')}

--- a/src/components/QuoteHistoryModal.tsx
+++ b/src/components/QuoteHistoryModal.tsx
@@ -147,7 +147,7 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
           contactName: quote.contact_name || '',
           phone: quote.site_phone || '',
           projectAddress: quote.site_address || '',
-          projectDescription: quote.scope_of_work || '',
+          additionalDetails: quote.scope_of_work || '',
         }
         
         onLoadQuote(loadedEquipmentData, quote.logistics_data || {})

--- a/src/components/QuoteSaveManager.tsx
+++ b/src/components/QuoteSaveManager.tsx
@@ -129,7 +129,7 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
           contactName: quote.contact_name || '',
           phone: quote.site_phone || '',
           projectAddress: quote.site_address || '',
-          projectDescription: quote.scope_of_work || '',
+          additionalDetails: quote.scope_of_work || '',
         }
         
         onLoadQuote(loadedEquipmentData, quote.logistics_data || {})

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -64,7 +64,7 @@ export class QuoteService {
         site_phone: equipmentData.phone || null,
         shop_location: 'Shop',
         site_address: equipmentData.projectAddress || null,
-        scope_of_work: equipmentData.projectDescription || null,
+        scope_of_work: equipmentData.additionalDetails || null,
         logistics_data: logisticsData || {},
         email_template: emailTemplate || null,
         scope_template: scopeTemplate || null,

--- a/supabase/functions/ai-extract-project/index.ts
+++ b/supabase/functions/ai-extract-project/index.ts
@@ -37,8 +37,7 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "projectAddress": "string",
     "city": "string",
     "state": "string",
-    "zipCode": "string",
-    "projectDescription": "string"
+    "zipCode": "string"
   },
   "logistics": {
     "pieces": [{"description": "string", "quantity": "number", "length": "number", "width": "number", "height": "number", "weight": "number"}],

--- a/supabase/functions/ai-extract-with-storage/index.ts
+++ b/supabase/functions/ai-extract-with-storage/index.ts
@@ -37,8 +37,7 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "projectAddress": "string",
     "city": "string",
     "state": "string",
-    "zipCode": "string",
-    "projectDescription": "string"
+    "zipCode": "string"
   },
   "logistics": {
     "pieces": [{"description": "string", "quantity": "number", "length": "number", "width": "number", "height": "number", "weight": "number"}],


### PR DESCRIPTION
## Summary
- remove project description dropdown from equipment form
- store additional details as scope of work and display in previews
- drop projectDescription from AI extraction functions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68befafb03888321b87da410c51c1a1b