### PR TITLE
Add equipment requirements section to quotes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,26 +9,33 @@ import {
   Archive, 
   Plus, 
   Minus, 
-  Search, 
-  Building, 
-  User, 
-  Phone, 
-  MapPin, 
-  Package, 
-  Truck, 
-  Key 
+  Building,
+  User,
+  Phone,
+  MapPin,
+  Package,
+  Truck,
+  Key
 } from 'lucide-react'
 import { useSessionId } from './hooks/useSessionId'
 import { useApiKey } from './hooks/useApiKey'
 import AIExtractorModal from './components/AIExtractorModal'
 import PreviewTemplates from './components/PreviewTemplates'
-import QuoteHistoryModal from './components/QuoteHistoryModal'
+import QuoteSaveManager from './components/QuoteSaveManager'
 import ApiKeySetup from './components/ApiKeySetup'
 import HubSpotContactSearch from './components/HubSpotContactSearch'
-import { HubSpotService, HubSpotContact } from './services/hubspotService'
+import { HubSpotContact } from './services/hubspotService'
+import EquipmentRequired, { EquipmentRequirements } from './components/EquipmentRequired'
 
 const App: React.FC = () => {
   // State for equipment form
+  const initialEquipmentRequirements: EquipmentRequirements = {
+    crewSize: '',
+    forkliftModels: [''],
+    tractors: [''],
+    trailers: ['']
+  }
+
   const [equipmentData, setEquipmentData] = useState({
     projectName: '',
     companyName: '',
@@ -39,7 +46,8 @@ const App: React.FC = () => {
     city: '',
     state: '',
     zipCode: '',
-    additionalDetails: ''
+    additionalDetails: '',
+    equipmentRequirements: initialEquipmentRequirements
   })
 
   // State for logistics form
@@ -128,8 +136,13 @@ const App: React.FC = () => {
     }
   }
 
+  const handleEquipmentRequirementsChange = (data: EquipmentRequirements) => {
+    setEquipmentData(prev => ({ ...prev, equipmentRequirements: data }))
+  }
+
   const handleAIExtraction = (extractedEquipmentData: any, extractedLogisticsData: any) => {
     if (extractedEquipmentData) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { projectDescription, ...rest } = extractedEquipmentData
       setEquipmentData(prev => ({ ...prev, ...rest }))
     }
@@ -138,8 +151,15 @@ const App: React.FC = () => {
     }
   }
 
-  const handleLoadQuote = (loadedEquipmentData: any, loadedLogisticsData: any) => {
-    setEquipmentData(loadedEquipmentData)
+  const handleLoadQuote = (
+    loadedEquipmentData: any,
+    loadedLogisticsData: any,
+    loadedEquipmentRequirements?: EquipmentRequirements
+  ) => {
+    setEquipmentData({
+      ...loadedEquipmentData,
+      equipmentRequirements: loadedEquipmentRequirements || initialEquipmentRequirements
+    })
     setLogisticsData({ truckType: '', ...loadedLogisticsData })
   }
 
@@ -368,6 +388,11 @@ const App: React.FC = () => {
                 />
               </div>
 
+              <EquipmentRequired
+                data={equipmentData.equipmentRequirements}
+                onChange={handleEquipmentRequirementsChange}
+              />
+
             </div>
           </div>
 
@@ -588,16 +613,18 @@ const App: React.FC = () => {
         <PreviewTemplates
           equipmentData={equipmentData}
           logisticsData={logisticsData}
+          equipmentRequirements={equipmentData.equipmentRequirements}
           isOpen={showPreview}
           onClose={() => setShowPreview(false)}
         />
 
-        <QuoteHistoryModal
+        <QuoteSaveManager
+          equipmentData={equipmentData}
+          equipmentRequirements={equipmentData.equipmentRequirements}
+          logisticsData={logisticsData}
           isOpen={showHistory}
           onClose={() => setShowHistory(false)}
           onLoadQuote={handleLoadQuote}
-          currentEquipmentData={equipmentData}
-          currentLogisticsData={logisticsData}
         />
 
         {showApiKeySetup && (

--- a/src/components/EquipmentRequired.tsx
+++ b/src/components/EquipmentRequired.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import { Plus, Minus, X } from 'lucide-react'
+
+export interface EquipmentRequirements {
+  crewSize: string
+  forkliftModels: string[]
+  tractors: string[]
+  trailers: string[]
+}
+
+interface EquipmentRequiredProps {
+  data: EquipmentRequirements
+  onChange: (data: EquipmentRequirements) => void
+}
+
+const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange }) => {
+  const handleFieldChange = <K extends keyof EquipmentRequirements>(
+    field: K,
+    value: EquipmentRequirements[K]
+  ) => {
+    onChange({ ...data, [field]: value })
+  }
+
+  const handleArrayChange = (
+    field: 'forkliftModels' | 'tractors' | 'trailers',
+    index: number,
+    value: string
+  ) => {
+    const updated = [...data[field]]
+    updated[index] = value
+    handleFieldChange(field, updated)
+  }
+
+  const addItem = (field: 'forkliftModels' | 'tractors' | 'trailers') => {
+    handleFieldChange(field, [...data[field], ''])
+  }
+
+  const removeItem = (field: 'forkliftModels' | 'tractors' | 'trailers', index: number) => {
+    const updated = data[field].filter((_, i) => i !== index)
+    handleFieldChange(field, updated)
+  }
+
+  const clearSection = () => {
+    onChange({ crewSize: '', forkliftModels: [''], tractors: [''], trailers: [''] })
+  }
+
+  const renderList = (label: string, field: 'forkliftModels' | 'tractors' | 'trailers') => (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <label className="block text-sm font-medium text-white">{label}</label>
+        <button
+          type="button"
+          onClick={() => addItem(field)}
+          className="p-1 bg-accent text-black rounded hover:bg-green-400 transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="space-y-2">
+        {data[field].map((item, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <input
+              type="text"
+              value={item}
+              onChange={(e) => handleArrayChange(field, index, e.target.value)}
+              className="flex-1 px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+              placeholder={`Enter ${label.toLowerCase().slice(0, -1)}`}
+            />
+            <button
+              type="button"
+              onClick={() => removeItem(field, index)}
+              className="p-1 bg-gray-900 border border-accent rounded hover:bg-gray-800"
+            >
+              <Minus className="w-4 h-4 text-white" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+
+  return (
+    <div className="mt-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xl font-bold text-white">Equipment Requirements</h3>
+        <button
+          type="button"
+          onClick={clearSection}
+          className="flex items-center px-3 py-1 bg-gray-900 border border-accent rounded-lg hover:bg-gray-800 transition-colors text-white"
+        >
+          <X className="w-4 h-4 mr-1" />
+          Clear Section
+        </button>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-white mb-2">Crew Size</label>
+        <input
+          type="text"
+          value={data.crewSize}
+          onChange={(e) => handleFieldChange('crewSize', e.target.value)}
+          className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+          placeholder="Enter crew size"
+        />
+      </div>
+
+      {renderList('Forklift Models', 'forkliftModels')}
+      {renderList('Tractors', 'tractors')}
+      {renderList('Trailers', 'trailers')}
+    </div>
+  )
+}
+
+export default EquipmentRequired

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -5,15 +5,17 @@ import { FileText, Mail, Copy, CheckCircle, Eye, X } from 'lucide-react'
 interface PreviewTemplatesProps {
   equipmentData: any
   logisticsData: any
+  equipmentRequirements: any
   isOpen: boolean
   onClose: () => void
 }
 
-const PreviewTemplates: React.FC<PreviewTemplatesProps> = ({ 
-  equipmentData, 
-  logisticsData, 
-  isOpen, 
-  onClose 
+const PreviewTemplates: React.FC<PreviewTemplatesProps> = ({
+  equipmentData,
+  logisticsData,
+  equipmentRequirements,
+  isOpen,
+  onClose
 }) => {
   const [activeTemplate, setActiveTemplate] = useState<'email' | 'scope'>('email')
   const [copiedTemplate, setCopiedTemplate] = useState<string | null>(null)
@@ -26,7 +28,21 @@ const PreviewTemplates: React.FC<PreviewTemplatesProps> = ({
     const city = equipmentData.city || '[City]'
     const state = equipmentData.state || '[State]'
     const additionalDetails = equipmentData.additionalDetails || ''
-    
+
+    const crewSize = equipmentRequirements.crewSize || ''
+    const forklifts = (equipmentRequirements.forkliftModels || []).filter((f: string) => f)
+    const tractors = (equipmentRequirements.tractors || []).filter((t: string) => t)
+    const trailers = (equipmentRequirements.trailers || []).filter((t: string) => t)
+
+    const equipmentLines =
+      crewSize || forklifts.length || tractors.length || trailers.length
+        ? `EQUIPMENT REQUIREMENTS:\n${
+            crewSize ? `• Crew Size: ${crewSize}\n` : ''
+          }${forklifts.length ? `• Forklifts: ${forklifts.join(', ')}\n` : ''}${
+            tractors.length ? `• Tractors: ${tractors.join(', ')}\n` : ''
+          }${trailers.length ? `• Trailers: ${trailers.join(', ')}` : ''}\n\n`
+        : ''
+
     const pickupAddress = logisticsData.pickupAddress || projectAddress
     const pickupCity = logisticsData.pickupCity || city
     const pickupState = logisticsData.pickupState || state
@@ -48,16 +64,27 @@ PROJECT DETAILS:
 • Contact: ${contactName}
 • Project Location: ${projectAddress}, ${city}, ${state}
 
-${additionalDetails ? `ADDITIONAL DETAILS:\n${additionalDetails}\n\n` : ''}LOGISTICS REQUIREMENTS:
+${additionalDetails ? `ADDITIONAL DETAILS:\n${additionalDetails}\n\n` : ''}${equipmentLines}LOGISTICS REQUIREMENTS:
 • Pickup Location: ${pickupAddress}, ${pickupCity}, ${pickupState}
 • Delivery Location: ${deliveryAddress}, ${deliveryCity}, ${deliveryState}
 • Service Type: ${logisticsData.serviceType || 'Standard Delivery'}
 ${logisticsData.truckType ? `• Truck Type: ${logisticsData.truckType}` : ''}
 
-    ${logisticsData.pieces && logisticsData.pieces.length > 0 ? `ITEMS TO TRANSPORT:
-    ${logisticsData.pieces.map((piece: any, index: number) =>
-      `${index + 1}. (Qty: ${piece.quantity || 1}) ${piece.description || '[Description]'} - ${piece.length || '[L]'}"L x ${piece.width || '[W]'}"W x ${piece.height || '[H]'}"H, ${piece.weight || '[Weight]'} lbs`
-    ).join('\n')}` : ''}
+    ${
+      logisticsData.pieces && logisticsData.pieces.length > 0
+        ? `ITEMS TO TRANSPORT:
+    ${logisticsData.pieces
+      .map(
+        (piece: any, index: number) =>
+          `${index + 1}. (Qty: ${piece.quantity || 1}) ${
+            piece.description || '[Description]'
+          } - ${piece.length || '[L]'}"L x ${piece.width || '[W]'}"W x ${
+            piece.height || '[H]'
+          }"H, ${piece.weight || '[Weight]'} lbs`
+      )
+      .join('\n')}`
+        : ''
+    }
 
 Please provide a detailed quote including all equipment, labor, and transportation costs. We would appreciate receiving this quote at your earliest convenience.
 
@@ -78,6 +105,20 @@ ${equipmentData.phone || '[Phone]'}`
     const contactName = equipmentData.contactName || '[Site Contact]'
     const phone = equipmentData.phone || '[Site Contact Phone Number]'
 
+    const crewSize = equipmentRequirements.crewSize || '[Crew Size]'
+    const forklifts = (equipmentRequirements.forkliftModels || []).filter((f: string) => f)
+    const tractors = (equipmentRequirements.tractors || []).filter((t: string) => t)
+    const trailers = (equipmentRequirements.trailers || []).filter((t: string) => t)
+
+    const equipmentSummary = [
+      crewSize ? `${crewSize} crew` : '',
+      forklifts.length ? `${forklifts.join(', ')} forklift(s)` : '',
+      tractors.length ? `${tractors.join(', ')} tractor(s)` : '',
+      trailers.length ? `${trailers.join(', ')} trailer(s)` : ''
+    ]
+      .filter(Boolean)
+      .join(', ')
+
     return `SCOPE OF WORK
 
 Mobilize crew and Omega Morgan equipment to site: ${projectAddress}, ${city}, ${state}
@@ -85,14 +126,31 @@ Mobilize crew and Omega Morgan equipment to site: ${projectAddress}, ${city}, ${
 ${contactName}
 ${phone}
 
-Omega Morgan to supply 3-man crew, Gear Truck and Trailer.
+Omega Morgan to supply ${
+      equipmentSummary || 'necessary crew and equipment'
+    }.
 
-${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n\n` : ''}${equipmentData.additionalDetails ? `${equipmentData.additionalDetails}\n\n` : ''}${logisticsData.pieces && logisticsData.pieces.length > 0 ? `ITEMS TO HANDLE:
-${logisticsData.pieces.map((piece: any) =>
-  `• (Qty: ${piece.quantity || 1}) ${piece.description || '[Item Description]'} - ${piece.length || '[L]'}"L x ${piece.width || '[W]'}"W x ${piece.height || '[H]'}"H, ${piece.weight || '[Weight]'} lbs`
-).join('\n')}
+${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n\n` : ''}${
+      equipmentData.additionalDetails
+        ? `${equipmentData.additionalDetails}\n\n`
+        : ''
+    }${
+      logisticsData.pieces && logisticsData.pieces.length > 0
+        ? `ITEMS TO HANDLE:
+${logisticsData.pieces
+  .map(
+    (piece: any) =>
+      `• (Qty: ${piece.quantity || 1}) ${piece.description || '[Item Description]'} - ${
+        piece.length || '[L]'
+      }"L x ${piece.width || '[W]'}"W x ${piece.height || '[H]'}"H, ${
+        piece.weight || '[Weight]'
+      } lbs`
+  )
+  .join('\n')}
 
-` : ''}When job is complete clean up debris and return to [Shop].`
+`
+        : ''
+    }When job is complete clean up debris and return to [Shop].`
   }
 
   const copyToClipboard = async (text: string, templateType: string) => {

--- a/src/components/QuoteHistoryModal.tsx
+++ b/src/components/QuoteHistoryModal.tsx
@@ -1,12 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect } from 'react'
 import { Archive, Search, Trash2, Download, Save, X, Calendar, Building, User, FileText, Loader, CheckCircle, AlertCircle, Plus } from 'lucide-react'
-import { QuoteService, QuoteListItem, SavedQuote } from '../services/quoteService'
+import { QuoteService, QuoteListItem } from '../services/quoteService'
 
 interface QuoteHistoryModalProps {
   isOpen: boolean
   onClose: () => void
-  onLoadQuote: (equipmentData: any, logisticsData: any) => void
+  onLoadQuote: (
+    equipmentData: any,
+    logisticsData: any,
+    equipmentRequirements: any
+  ) => void
   currentEquipmentData: any
   currentLogisticsData: any
 }
@@ -53,8 +57,8 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
     try {
       const quoteList = await QuoteService.listQuotes()
       setQuotes(quoteList)
-    } catch (error) {
-      console.error('Error loading quotes:', error)
+    } catch {
+      console.error('Error loading quotes')
       setMessage({ type: 'error', text: 'Failed to load quote history' })
     } finally {
       setLoading(false)
@@ -68,8 +72,8 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
     try {
       const results = await QuoteService.searchQuotes(searchTerm)
       setQuotes(results)
-    } catch (error) {
-      console.error('Error searching quotes:', error)
+    } catch {
+      console.error('Error searching quotes')
       setMessage({ type: 'error', text: 'Failed to search quotes' })
     } finally {
       setLoading(false)
@@ -89,7 +93,8 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
       const result = await QuoteService.saveQuote(
         quoteNumber,
         currentEquipmentData,
-        currentLogisticsData
+        currentLogisticsData,
+        currentEquipmentData.equipmentRequirements
       )
 
       if (result.success) {
@@ -99,7 +104,7 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
       } else {
         setMessage({ type: 'error', text: result.error || 'Failed to save quote' })
       }
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: 'Failed to save quote' })
     } finally {
       setLoading(false)
@@ -117,6 +122,7 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
         quoteNumber,
         currentEquipmentData,
         currentLogisticsData,
+        currentEquipmentData.equipmentRequirements,
         undefined,
         undefined,
         selectedQuote
@@ -129,7 +135,7 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
       } else {
         setMessage({ type: 'error', text: result.error || 'Failed to update quote' })
       }
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: 'Failed to update quote' })
     } finally {
       setLoading(false)
@@ -149,12 +155,20 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
           projectAddress: quote.site_address || '',
           additionalDetails: quote.scope_of_work || '',
         }
-        
-        onLoadQuote(loadedEquipmentData, quote.logistics_data || {})
+
+        const loadedRequirements =
+          quote.equipment_requirements || {
+            crewSize: '',
+            forkliftModels: [],
+            tractors: [],
+            trailers: []
+          }
+
+        onLoadQuote(loadedEquipmentData, quote.logistics_data || {}, loadedRequirements)
         setMessage({ type: 'success', text: 'Quote loaded successfully!' })
         setTimeout(() => onClose(), 1500) // Close modal after success message
       }
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: 'Failed to load quote' })
     } finally {
       setLoading(false)
@@ -174,7 +188,7 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
       } else {
         setMessage({ type: 'error', text: 'Failed to delete quote' })
       }
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: 'Failed to delete quote' })
     } finally {
       setLoading(false)

--- a/src/components/QuoteSaveManager.tsx
+++ b/src/components/QuoteSaveManager.tsx
@@ -1,14 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect } from 'react'
 import { Save, History, Search, Trash2, Edit3, Copy, Calendar, Building, User, FileText, X, Plus } from 'lucide-react'
-import { QuoteService, QuoteListItem, SavedQuote } from '../services/quoteService'
+import { QuoteService, QuoteListItem } from '../services/quoteService'
 
 interface QuoteSaveManagerProps {
   equipmentData: any
   logisticsData: any
+  equipmentRequirements: any
   emailTemplate?: string
   scopeTemplate?: string
-  onLoadQuote: (equipmentData: any, logisticsData: any) => void
+  onLoadQuote: (
+    equipmentData: any,
+    logisticsData: any,
+    equipmentRequirements: any
+  ) => void
   isOpen: boolean
   onClose: () => void
 }
@@ -16,6 +21,7 @@ interface QuoteSaveManagerProps {
 const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
   equipmentData,
   logisticsData,
+  equipmentRequirements,
   emailTemplate,
   scopeTemplate,
   onLoadQuote,
@@ -95,6 +101,7 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
         quoteNumber,
         equipmentData,
         logisticsData,
+        equipmentRequirements,
         emailTemplate,
         scopeTemplate,
         overwriteId
@@ -110,7 +117,7 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
       } else {
         setMessage({ type: 'error', text: result.error || 'Failed to save quote' })
       }
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: 'Failed to save quote' })
     } finally {
       setLoading(false)
@@ -131,12 +138,20 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
           projectAddress: quote.site_address || '',
           additionalDetails: quote.scope_of_work || '',
         }
-        
-        onLoadQuote(loadedEquipmentData, quote.logistics_data || {})
+
+        const loadedRequirements =
+          quote.equipment_requirements || {
+            crewSize: '',
+            forkliftModels: [],
+            tractors: [],
+            trailers: []
+          }
+
+        onLoadQuote(loadedEquipmentData, quote.logistics_data || {}, loadedRequirements)
         setMessage({ type: 'success', text: 'Quote loaded successfully!' })
         setShowHistory(false)
       }
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: 'Failed to load quote' })
     } finally {
       setLoading(false)
@@ -156,7 +171,7 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
       } else {
         setMessage({ type: 'error', text: 'Failed to delete quote' })
       }
-    } catch (error) {
+    } catch {
       setMessage({ type: 'error', text: 'Failed to delete quote' })
     } finally {
       setLoading(false)

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { supabase } from '../lib/supabase'
 
 export interface QuoteListItem {
@@ -21,6 +22,7 @@ export interface SavedQuote {
   site_address: string | null
   scope_of_work: string | null
   logistics_data: any
+  equipment_requirements: any
   email_template: string | null
   scope_template: string | null
   created_at: string
@@ -48,9 +50,10 @@ export class QuoteService {
   }
 
   static async saveQuote(
-    quoteNumber: string, 
-    equipmentData: any, 
+    quoteNumber: string,
+    equipmentData: any,
     logisticsData: any,
+    equipmentRequirements: any,
     emailTemplate?: string,
     scopeTemplate?: string,
     existingId?: string
@@ -66,6 +69,7 @@ export class QuoteService {
         site_address: equipmentData.projectAddress || null,
         scope_of_work: equipmentData.additionalDetails || null,
         logistics_data: logisticsData || {},
+        equipment_requirements: equipmentRequirements || null,
         email_template: emailTemplate || null,
         scope_template: scopeTemplate || null,
       }


### PR DESCRIPTION
## Summary
- add EquipmentRequired component with crew size, forklifts, tractors and trailers plus add/remove and clear controls
- wire equipment requirements through App, preview templates and quote saving for persistence
- extend quote service to store equipment requirements data

## Testing
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore" in supabase/functions/hubspot-search/index.ts)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68beffeb98808321a8bdf3fe3f71fd63