### PR TITLE
Add shipment type selection to logistics form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ const App: React.FC = () => {
     deliveryState: '',
     deliveryZip: '',
     serviceType: 'Standard Delivery',
+    shipmentType: 'LTL',
     truckType: ''
   })
 
@@ -147,7 +148,7 @@ const App: React.FC = () => {
       ...loadedEquipmentData,
       equipmentRequirements: loadedEquipmentRequirements || initialEquipmentRequirements
     })
-    setLogisticsData({ truckType: '', ...loadedLogisticsData })
+    setLogisticsData({ truckType: '', shipmentType: 'LTL', ...loadedLogisticsData })
   }
 
   const handleApiKeyChange = () => {
@@ -403,6 +404,19 @@ const App: React.FC = () => {
                   <option value="White Glove">White Glove</option>
                   <option value="Inside Delivery">Inside Delivery</option>
                   <option value="Curbside">Curbside</option>
+                </select>
+              </div>
+
+              {/* Shipment Type */}
+              <div>
+                <label className="block text-sm font-medium text-white mb-2">Shipment Type</label>
+                <select
+                  value={logisticsData.shipmentType}
+                  onChange={(e) => handleLogisticsChange('shipmentType', e.target.value)}
+                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                >
+                  <option value="LTL">LTL</option>
+                  <option value="FTL">FTL</option>
                 </select>
               </div>
 

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -65,6 +65,7 @@ ${scopeOfWork ? `SCOPE OF WORK:\n${scopeOfWork}\n\n` : ''}${equipmentLines}LOGIS
 • Pickup Location: ${pickupAddress}
 • Delivery Location: ${deliveryAddress}
 • Service Type: ${logisticsData.serviceType || 'Standard Delivery'}
+• Shipment Type: ${logisticsData.shipmentType || 'LTL'}
 ${logisticsData.truckType ? `• Truck Type: ${logisticsData.truckType}` : ''}
 
     ${
@@ -127,7 +128,8 @@ Omega Morgan to supply ${
       equipmentSummary || 'necessary crew and equipment'
     }.
 
-${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n\n` : ''}${
+Shipment Type: ${logisticsData.shipmentType || 'LTL'}
+${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n\n` : '\n'}${
       scopeOfWork ? `${scopeOfWork}\n\n` : ''
     }${
       logisticsData.pieces && logisticsData.pieces.length > 0

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -68,7 +68,7 @@ export class QuoteService {
         shop_location: equipmentData.shopLocation || null,
         site_address: equipmentData.siteAddress || null,
         scope_of_work: equipmentData.scopeOfWork || null,
-        logistics_data: logisticsData || {},
+        logistics_data: { shipmentType: logisticsData?.shipmentType || 'LTL', ...logisticsData },
         equipment_requirements: equipmentRequirements || null,
         email_template: emailTemplate || null,
         scope_template: scopeTemplate || null,


### PR DESCRIPTION
## Summary
- add `shipmentType` to logistics state with default `LTL`
- expose Shipment Type selector in logistics form
- propagate `shipmentType` through templates and quote saving

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors in unrelated files)
- `npx eslint src/App.tsx src/components/PreviewTemplates.tsx src/services/quoteService.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf3256456c83219b24477015043c76