### PR TITLE
feat: add storage selections to logistics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,7 +56,9 @@ const App: React.FC = () => {
     deliveryZip: '',
     serviceType: 'Standard Delivery',
     shipmentType: 'LTL',
-    truckType: ''
+    truckType: '',
+    storageType: '',
+    storageSqFt: ''
   })
 
   // Modal states
@@ -148,7 +150,13 @@ const App: React.FC = () => {
       ...loadedEquipmentData,
       equipmentRequirements: loadedEquipmentRequirements || initialEquipmentRequirements
     })
-    setLogisticsData({ truckType: '', shipmentType: 'LTL', ...loadedLogisticsData })
+    setLogisticsData({
+      truckType: '',
+      shipmentType: 'LTL',
+      storageType: '',
+      storageSqFt: '',
+      ...loadedLogisticsData
+    })
   }
 
   const handleApiKeyChange = () => {
@@ -433,6 +441,30 @@ const App: React.FC = () => {
                   <option value="Flatbed with tarp">Flatbed with tarp</option>
                   <option value="Conestoga">Conestoga</option>
                 </select>
+              </div>
+
+              {/* Storage Requirements */}
+              <div>
+                <label className="block text-sm font-medium text-white mb-2">Storage</label>
+                <select
+                  value={logisticsData.storageType}
+                  onChange={(e) => handleLogisticsChange('storageType', e.target.value)}
+                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                >
+                  <option value="">No Storage</option>
+                  <option value="inside">Inside Storage ($1.50/sq ft)</option>
+                  <option value="outside">Outside Storage ($0.75/sq ft)</option>
+                </select>
+                {logisticsData.storageType && (
+                  <input
+                    type="number"
+                    value={logisticsData.storageSqFt}
+                    onChange={(e) => handleLogisticsChange('storageSqFt', e.target.value)}
+                    className="mt-2 w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                    placeholder="Square footage"
+                    min="0"
+                  />
+                )}
               </div>
 
             </div>

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -46,6 +46,9 @@ const PreviewTemplates: React.FC<PreviewTemplatesProps> = ({
     const pickupAddress = logisticsData.pickupAddress || siteAddress
     const deliveryAddress = logisticsData.deliveryAddress || '[Delivery Address]'
 
+    const storageLine = logisticsData.storageType
+      ? `• Storage: ${logisticsData.storageType === 'inside' ? 'Inside' : 'Outside'} (${logisticsData.storageSqFt || '[Sq Ft]'} sq ft)`
+      : ''
 
     return `Subject: Quote Request - ${projectName}
 
@@ -61,12 +64,12 @@ PROJECT DETAILS:
 • Site Address: ${siteAddress}
 • Shop Location: ${shopLocation}
 
-${scopeOfWork ? `SCOPE OF WORK:\n${scopeOfWork}\n\n` : ''}${equipmentLines}LOGISTICS REQUIREMENTS:
-• Pickup Location: ${pickupAddress}
-• Delivery Location: ${deliveryAddress}
-• Service Type: ${logisticsData.serviceType || 'Standard Delivery'}
-• Shipment Type: ${logisticsData.shipmentType || 'LTL'}
-${logisticsData.truckType ? `• Truck Type: ${logisticsData.truckType}` : ''}
+    ${scopeOfWork ? `SCOPE OF WORK:\n${scopeOfWork}\n\n` : ''}${equipmentLines}LOGISTICS REQUIREMENTS:
+    • Pickup Location: ${pickupAddress}
+    • Delivery Location: ${deliveryAddress}
+    • Service Type: ${logisticsData.serviceType || 'Standard Delivery'}
+    • Shipment Type: ${logisticsData.shipmentType || 'LTL'}
+    ${storageLine ? `${storageLine}\n` : ''}${logisticsData.truckType ? `• Truck Type: ${logisticsData.truckType}` : ''}
 
     ${
       logisticsData.pieces && logisticsData.pieces.length > 0
@@ -117,6 +120,14 @@ ${sitePhone}`
       .filter(Boolean)
       .join(', ')
 
+    const storageLine = logisticsData.storageType
+      ? `Storage: ${
+          logisticsData.storageType === 'inside'
+            ? 'Inside Storage'
+            : 'Outside Storage'
+        } - ${logisticsData.storageSqFt || '[Sq Ft]'} sq ft`
+      : ''
+
     return `SCOPE OF WORK
 
 Mobilize crew and Omega Morgan equipment to site: ${siteAddress}
@@ -128,10 +139,10 @@ Omega Morgan to supply ${
       equipmentSummary || 'necessary crew and equipment'
     }.
 
-Shipment Type: ${logisticsData.shipmentType || 'LTL'}
-${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n\n` : '\n'}${
-      scopeOfWork ? `${scopeOfWork}\n\n` : ''
-    }${
+  Shipment Type: ${logisticsData.shipmentType || 'LTL'}
+  ${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n` : ''}${
+      storageLine ? `${storageLine}\n\n` : '\n'
+    }${scopeOfWork ? `${scopeOfWork}\n\n` : ''}${
       logisticsData.pieces && logisticsData.pieces.length > 0
         ? `ITEMS TO HANDLE:
 ${logisticsData.pieces

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -68,7 +68,12 @@ export class QuoteService {
         shop_location: equipmentData.shopLocation || null,
         site_address: equipmentData.siteAddress || null,
         scope_of_work: equipmentData.scopeOfWork || null,
-        logistics_data: { shipmentType: logisticsData?.shipmentType || 'LTL', ...logisticsData },
+        logistics_data: {
+          ...logisticsData,
+          shipmentType: logisticsData?.shipmentType || 'LTL',
+          storageType: logisticsData?.storageType || '',
+          storageSqFt: logisticsData?.storageSqFt || ''
+        },
         equipment_requirements: equipmentRequirements || null,
         email_template: emailTemplate || null,
         scope_template: scopeTemplate || null,


### PR DESCRIPTION
## Summary
- add storage type and square-footage to logistics form
- include storage info in preview templates
- persist storage fields when saving quotes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore", etc. in supabase/functions/hubspot-search/index.ts)*
- `npx eslint src/App.tsx src/components/PreviewTemplates.tsx src/services/quoteService.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf3385e4e083219e4fada836860abf