### PR TITLE
feat: enrich templates with logistics details

### DIFF
--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -2,6 +2,161 @@
 import React, { useState } from 'react'
 import { FileText, Mail, Copy, CheckCircle, Eye, X } from 'lucide-react'
 
+export const generateEmailTemplate = (
+  equipmentData: any,
+  logisticsData: any,
+  equipmentRequirements: any
+) => {
+  const projectName = equipmentData.projectName || '[project name]'
+  const companyName = equipmentData.companyName || '[Company Name]'
+  const contactName = equipmentData.contactName || '[Contact Name]'
+  const siteAddress = equipmentData.siteAddress || '[Site Address]'
+  const sitePhone = equipmentData.sitePhone || '[Site Phone]'
+  const shopLocation = equipmentData.shopLocation || '[Shop Location]'
+  const scopeOfWork = equipmentData.scopeOfWork || ''
+
+  const crewSize = equipmentRequirements.crewSize || ''
+  const forklifts = (equipmentRequirements.forkliftModels || []).filter((f: string) => f)
+  const tractors = (equipmentRequirements.tractors || []).filter((t: string) => t)
+  const trailers = (equipmentRequirements.trailers || []).filter((t: string) => t)
+
+  const equipmentLines =
+    crewSize || forklifts.length || tractors.length || trailers.length
+      ? `EQUIPMENT REQUIREMENTS:\n${
+          crewSize ? `• Crew Size: ${crewSize}\n` : ''
+        }${forklifts.length ? `• Forklifts: ${forklifts.join(', ')}\n` : ''}${
+          tractors.length ? `• Tractors: ${tractors.join(', ')}\n` : ''
+        }${trailers.length ? `• Trailers: ${trailers.join(', ')}\n` : ''}\n`
+      : ''
+
+  const pickupAddress = logisticsData.pickupAddress || siteAddress
+  const deliveryAddress = logisticsData.deliveryAddress || ''
+
+  const logisticsLines = [
+    pickupAddress ? `• Pickup Location: ${pickupAddress}` : '',
+    deliveryAddress ? `• Delivery Location: ${deliveryAddress}` : '',
+    logisticsData.serviceType ? `• Service Type: ${logisticsData.serviceType}` : '',
+    logisticsData.shipmentType ? `• Shipment Type: ${logisticsData.shipmentType}` : '',
+    logisticsData.truckType ? `• Truck Type: ${logisticsData.truckType}` : '',
+    logisticsData.storageType
+      ? `• Storage: ${
+          logisticsData.storageType === 'inside' ? 'Inside' : 'Outside'
+        } (${logisticsData.storageSqFt || '[Sq Ft]'} sq ft)`
+      : ''
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  const logisticsSection = logisticsLines
+    ? `LOGISTICS REQUIREMENTS:\n${logisticsLines}\n\n`
+    : ''
+
+  const itemsSection =
+    logisticsData.pieces && logisticsData.pieces.length > 0
+      ? `ITEMS TO TRANSPORT:\n${logisticsData.pieces
+          .map(
+            (piece: any, index: number) =>
+              `${index + 1}. (Qty: ${piece.quantity || 1}) ${
+                piece.description || '[Description]'
+              } - ${piece.length || '[L]'}"L x ${piece.width || '[W]'}"W x ${
+                piece.height || '[H]'
+              }"H, ${piece.weight || '[Weight]'} lbs`
+          )
+          .join('\n')}\n\n`
+      : ''
+
+  return `Subject: Quote Request - ${projectName}
+
+Dear Omega Morgan Team,
+
+I hope this email finds you well. I am writing to request a quote for an upcoming project that requires your specialized equipment and logistics services.
+
+PROJECT DETAILS:
+• Project Name: ${projectName}
+• Company: ${companyName}
+• Contact: ${contactName}
+• Site Phone: ${sitePhone}
+• Site Address: ${siteAddress}
+• Shop Location: ${shopLocation}
+
+${scopeOfWork ? `SCOPE OF WORK:\n${scopeOfWork}\n\n` : ''}${equipmentLines}${logisticsSection}${itemsSection}Please provide a detailed quote including all equipment, labor, and transportation costs. We would appreciate receiving this quote at your earliest convenience.
+
+Thank you for your time and consideration. I look forward to hearing from you soon.
+
+Best regards,
+${contactName}
+${companyName}
+${equipmentData.email || '[Email]'}
+${sitePhone}`
+}
+
+export const generateScopeTemplate = (
+  equipmentData: any,
+  logisticsData: any,
+  equipmentRequirements: any
+) => {
+  const siteAddress = equipmentData.siteAddress || '[Site Address]'
+  const contactName = equipmentData.contactName || '[Site Contact]'
+  const phone = equipmentData.sitePhone || '[Site Contact Phone Number]'
+  const shopLocation = equipmentData.shopLocation || '[Shop]'
+  const scopeOfWork = equipmentData.scopeOfWork || ''
+
+  const crewSize = equipmentRequirements.crewSize || ''
+  const forklifts = (equipmentRequirements.forkliftModels || []).filter((f: string) => f)
+  const tractors = (equipmentRequirements.tractors || []).filter((t: string) => t)
+  const trailers = (equipmentRequirements.trailers || []).filter((t: string) => t)
+
+  const equipmentSummary = [
+    crewSize ? `${crewSize} crew` : '',
+    forklifts.length ? `${forklifts.join(', ')} forklift(s)` : '',
+    tractors.length ? `${tractors.join(', ')} tractor(s)` : '',
+    trailers.length ? `${trailers.join(', ')} trailer(s)` : ''
+  ]
+    .filter(Boolean)
+    .join(', ')
+
+  const shipmentLine = logisticsData.shipmentType
+    ? `Shipment Type: ${logisticsData.shipmentType}\n`
+    : ''
+  const truckLine = logisticsData.truckType
+    ? `Truck Type Requested: ${logisticsData.truckType}\n`
+    : ''
+  const storageLine = logisticsData.storageType
+    ? `Storage: ${
+        logisticsData.storageType === 'inside' ? 'Inside Storage' : 'Outside Storage'
+      } - ${logisticsData.storageSqFt || '[Sq Ft]'} sq ft\n`
+    : ''
+
+  const logisticsSection =
+    shipmentLine || truckLine || storageLine
+      ? `\n${shipmentLine}${truckLine}${storageLine}`
+      : '\n'
+
+  const itemsSection =
+    logisticsData.pieces && logisticsData.pieces.length > 0
+      ? `ITEMS TO HANDLE:\n${logisticsData.pieces
+          .map(
+            (piece: any) =>
+              `• (Qty: ${piece.quantity || 1}) ${
+                piece.description || '[Item Description]'
+              } - ${piece.length || '[L]'}"L x ${piece.width || '[W]'}"W x ${
+                piece.height || '[H]'
+              }"H, ${piece.weight || '[Weight]'} lbs`
+          )
+          .join('\n')}\n`
+      : ''
+
+  return `SCOPE OF WORK
+
+Mobilize crew and Omega Morgan equipment to site: ${siteAddress}
+
+${contactName}
+${phone}
+
+Omega Morgan to supply ${equipmentSummary || 'necessary crew and equipment'}.
+${logisticsSection}${scopeOfWork ? `${scopeOfWork}\n\n` : ''}${itemsSection}When job is complete clean up debris and return to ${shopLocation}.`
+}
+
 interface PreviewTemplatesProps {
   equipmentData: any
   logisticsData: any
@@ -20,145 +175,16 @@ const PreviewTemplates: React.FC<PreviewTemplatesProps> = ({
   const [activeTemplate, setActiveTemplate] = useState<'email' | 'scope'>('email')
   const [copiedTemplate, setCopiedTemplate] = useState<string | null>(null)
 
-  const generateEmailTemplate = () => {
-    const projectName = equipmentData.projectName || '[project name]'
-    const companyName = equipmentData.companyName || '[Company Name]'
-    const contactName = equipmentData.contactName || '[Contact Name]'
-    const siteAddress = equipmentData.siteAddress || '[Site Address]'
-    const sitePhone = equipmentData.sitePhone || '[Site Phone]'
-    const shopLocation = equipmentData.shopLocation || '[Shop Location]'
-    const scopeOfWork = equipmentData.scopeOfWork || ''
-
-    const crewSize = equipmentRequirements.crewSize || ''
-    const forklifts = (equipmentRequirements.forkliftModels || []).filter((f: string) => f)
-    const tractors = (equipmentRequirements.tractors || []).filter((t: string) => t)
-    const trailers = (equipmentRequirements.trailers || []).filter((t: string) => t)
-
-    const equipmentLines =
-      crewSize || forklifts.length || tractors.length || trailers.length
-        ? `EQUIPMENT REQUIREMENTS:\n${
-            crewSize ? `• Crew Size: ${crewSize}\n` : ''
-          }${forklifts.length ? `• Forklifts: ${forklifts.join(', ')}\n` : ''}${
-            tractors.length ? `• Tractors: ${tractors.join(', ')}\n` : ''
-          }${trailers.length ? `• Trailers: ${trailers.join(', ')}` : ''}\n\n`
-        : ''
-
-    const pickupAddress = logisticsData.pickupAddress || siteAddress
-    const deliveryAddress = logisticsData.deliveryAddress || '[Delivery Address]'
-
-    const storageLine = logisticsData.storageType
-      ? `• Storage: ${logisticsData.storageType === 'inside' ? 'Inside' : 'Outside'} (${logisticsData.storageSqFt || '[Sq Ft]'} sq ft)`
-      : ''
-
-    return `Subject: Quote Request - ${projectName}
-
-Dear Omega Morgan Team,
-
-I hope this email finds you well. I am writing to request a quote for an upcoming project that requires your specialized equipment and logistics services.
-
-PROJECT DETAILS:
-• Project Name: ${projectName}
-• Company: ${companyName}
-• Contact: ${contactName}
-• Site Phone: ${sitePhone}
-• Site Address: ${siteAddress}
-• Shop Location: ${shopLocation}
-
-    ${scopeOfWork ? `SCOPE OF WORK:\n${scopeOfWork}\n\n` : ''}${equipmentLines}LOGISTICS REQUIREMENTS:
-    • Pickup Location: ${pickupAddress}
-    • Delivery Location: ${deliveryAddress}
-    • Service Type: ${logisticsData.serviceType || 'Standard Delivery'}
-    • Shipment Type: ${logisticsData.shipmentType || 'LTL'}
-    ${storageLine ? `${storageLine}\n` : ''}${logisticsData.truckType ? `• Truck Type: ${logisticsData.truckType}` : ''}
-
-    ${
-      logisticsData.pieces && logisticsData.pieces.length > 0
-        ? `ITEMS TO TRANSPORT:
-    ${logisticsData.pieces
-      .map(
-        (piece: any, index: number) =>
-          `${index + 1}. (Qty: ${piece.quantity || 1}) ${
-            piece.description || '[Description]'
-          } - ${piece.length || '[L]'}"L x ${piece.width || '[W]'}"W x ${
-            piece.height || '[H]'
-          }"H, ${piece.weight || '[Weight]'} lbs`
-      )
-      .join('\n')}`
-        : ''
-    }
-
-Please provide a detailed quote including all equipment, labor, and transportation costs. We would appreciate receiving this quote at your earliest convenience.
-
-
-Thank you for your time and consideration. I look forward to hearing from you soon.
-
-Best regards,
-${contactName}
-${companyName}
-${equipmentData.email || '[Email]'}
-${sitePhone}`
-  }
-
-  const generateScopeTemplate = () => {
-    const siteAddress = equipmentData.siteAddress || '[Site Address]'
-    const contactName = equipmentData.contactName || '[Site Contact]'
-    const phone = equipmentData.sitePhone || '[Site Contact Phone Number]'
-    const shopLocation = equipmentData.shopLocation || '[Shop]'
-    const scopeOfWork = equipmentData.scopeOfWork || ''
-
-    const crewSize = equipmentRequirements.crewSize || '[Crew Size]'
-    const forklifts = (equipmentRequirements.forkliftModels || []).filter((f: string) => f)
-    const tractors = (equipmentRequirements.tractors || []).filter((t: string) => t)
-    const trailers = (equipmentRequirements.trailers || []).filter((t: string) => t)
-
-    const equipmentSummary = [
-      crewSize ? `${crewSize} crew` : '',
-      forklifts.length ? `${forklifts.join(', ')} forklift(s)` : '',
-      tractors.length ? `${tractors.join(', ')} tractor(s)` : '',
-      trailers.length ? `${trailers.join(', ')} trailer(s)` : ''
-    ]
-      .filter(Boolean)
-      .join(', ')
-
-    const storageLine = logisticsData.storageType
-      ? `Storage: ${
-          logisticsData.storageType === 'inside'
-            ? 'Inside Storage'
-            : 'Outside Storage'
-        } - ${logisticsData.storageSqFt || '[Sq Ft]'} sq ft`
-      : ''
-
-    return `SCOPE OF WORK
-
-Mobilize crew and Omega Morgan equipment to site: ${siteAddress}
-
-${contactName}
-${phone}
-
-Omega Morgan to supply ${
-      equipmentSummary || 'necessary crew and equipment'
-    }.
-
-  Shipment Type: ${logisticsData.shipmentType || 'LTL'}
-  ${logisticsData.truckType ? `Truck Type Requested: ${logisticsData.truckType}\n` : ''}${
-      storageLine ? `${storageLine}\n\n` : '\n'
-    }${scopeOfWork ? `${scopeOfWork}\n\n` : ''}${
-      logisticsData.pieces && logisticsData.pieces.length > 0
-        ? `ITEMS TO HANDLE:
-${logisticsData.pieces
-  .map(
-    (piece: any) =>
-      `• (Qty: ${piece.quantity || 1}) ${piece.description || '[Item Description]'} - ${
-        piece.length || '[L]'
-      }"L x ${piece.width || '[W]'}"W x ${piece.height || '[H]'}"H, ${
-        piece.weight || '[Weight]'
-      } lbs`
+  const emailTemplate = generateEmailTemplate(
+    equipmentData,
+    logisticsData,
+    equipmentRequirements
   )
-  .join('\n')}
-\n`
-        : ''
-    }When job is complete clean up debris and return to ${shopLocation}.`
-  }
+  const scopeTemplate = generateScopeTemplate(
+    equipmentData,
+    logisticsData,
+    equipmentRequirements
+  )
 
   const copyToClipboard = async (text: string, templateType: string) => {
     try {
@@ -172,9 +198,6 @@ ${logisticsData.pieces
 
   if (!isOpen) return null
 
-  const emailTemplate = generateEmailTemplate()
-  const scopeTemplate = generateScopeTemplate()
-
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-gray-900 border-2 border-accent rounded-2xl text-white shadow-2xl w-full max-w-4xl h-[80vh] flex flex-col">
@@ -182,7 +205,7 @@ ${logisticsData.pieces
         <div className="flex items-center justify-between p-6 border-b-2 border-accent">
           <div className="flex items-center">
             <Eye className="w-6 h-6 text-white mr-2" />
-            <h3 className="text-xl font-bold text-white">Preview Te</h3>
+            <h3 className="text-xl font-bold text-white">Preview Templates</h3>
           </div>
           <button
             onClick={onClose}
@@ -226,10 +249,12 @@ ${logisticsData.pieces
                 {activeTemplate === 'email' ? 'Email Template' : 'Scope of Work Template'}
               </h4>
               <button
-                onClick={() => copyToClipboard(
-                  activeTemplate === 'email' ? emailTemplate : scopeTemplate,
-                  activeTemplate
-                )}
+                onClick={() =>
+                  copyToClipboard(
+                    activeTemplate === 'email' ? emailTemplate : scopeTemplate,
+                    activeTemplate
+                  )
+                }
                 className="flex items-center px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 hover:text-white transition-colors"
               >
                 {copiedTemplate === activeTemplate ? (

--- a/src/components/QuoteSaveManager.tsx
+++ b/src/components/QuoteSaveManager.tsx
@@ -2,17 +2,18 @@
 import React, { useState, useEffect } from 'react'
 import { Save, History, Search, Trash2, Edit3, Copy, Calendar, Building, User, FileText, X, Plus } from 'lucide-react'
 import { QuoteService, QuoteListItem } from '../services/quoteService'
+import { generateEmailTemplate, generateScopeTemplate } from './PreviewTemplates'
 
 interface QuoteSaveManagerProps {
   equipmentData: any
   logisticsData: any
   equipmentRequirements: any
-  emailTemplate?: string
-  scopeTemplate?: string
   onLoadQuote: (
     equipmentData: any,
     logisticsData: any,
-    equipmentRequirements: any
+    equipmentRequirements: any,
+    emailTemplate: string,
+    scopeTemplate: string
   ) => void
   isOpen: boolean
   onClose: () => void
@@ -22,8 +23,6 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
   equipmentData,
   logisticsData,
   equipmentRequirements,
-  emailTemplate,
-  scopeTemplate,
   onLoadQuote,
   isOpen,
   onClose
@@ -97,6 +96,17 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
     setMessage(null)
 
     try {
+      const emailTemplate = generateEmailTemplate(
+        equipmentData,
+        logisticsData,
+        equipmentRequirements
+      )
+      const scopeTemplate = generateScopeTemplate(
+        equipmentData,
+        logisticsData,
+        equipmentRequirements
+      )
+
       const result = await QuoteService.saveQuote(
         quoteNumber,
         equipmentData,
@@ -149,7 +159,13 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
             trailers: []
           }
 
-        onLoadQuote(loadedEquipmentData, quote.logistics_data || {}, loadedRequirements)
+        onLoadQuote(
+          loadedEquipmentData,
+          quote.logistics_data || {},
+          loadedRequirements,
+          quote.email_template || '',
+          quote.scope_template || ''
+        )
         setMessage({ type: 'success', text: 'Quote loaded successfully!' })
         setShowHistory(false)
       }


### PR DESCRIPTION
## Summary
- include shipment, storage, and equipment details in generated email and scope templates
- generate and persist templates when saving or loading quotes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/PreviewTemplates.tsx src/components/QuoteSaveManager.tsx src/App.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf34f7b1048321b9225ee941837886