### PR TITLE
feat: save new logistics sections

### DIFF
--- a/src/components/QuoteHistoryModal.tsx
+++ b/src/components/QuoteHistoryModal.tsx
@@ -166,7 +166,13 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
             trailers: []
           }
 
-        onLoadQuote(loadedEquipmentData, quote.logistics_data || {}, loadedRequirements)
+        const loadedLogisticsData = {
+          ...(quote.logistics_data || {}),
+          ...(quote.logistics_shipment ? { shipment: quote.logistics_shipment } : {}),
+          ...(quote.logistics_storage ? { storage: quote.logistics_storage } : {})
+        }
+
+        onLoadQuote(loadedEquipmentData, loadedLogisticsData, loadedRequirements)
         setMessage({ type: 'success', text: 'Quote loaded successfully!' })
         setTimeout(() => onClose(), 1500) // Close modal after success message
       }

--- a/src/components/QuoteSaveManager.tsx
+++ b/src/components/QuoteSaveManager.tsx
@@ -159,9 +159,15 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
             trailers: []
           }
 
+        const loadedLogisticsData = {
+          ...(quote.logistics_data || {}),
+          ...(quote.logistics_shipment ? { shipment: quote.logistics_shipment } : {}),
+          ...(quote.logistics_storage ? { storage: quote.logistics_storage } : {})
+        }
+
         onLoadQuote(
           loadedEquipmentData,
-          quote.logistics_data || {},
+          loadedLogisticsData,
           loadedRequirements,
           quote.email_template || '',
           quote.scope_template || ''

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -22,6 +22,8 @@ export interface SavedQuote {
   site_address: string | null
   scope_of_work: string | null
   logistics_data: any
+  logistics_shipment: any
+  logistics_storage: any
   equipment_requirements: any
   email_template: string | null
   scope_template: string | null
@@ -74,6 +76,8 @@ export class QuoteService {
           storageType: logisticsData?.storageType || '',
           storageSqFt: logisticsData?.storageSqFt || ''
         },
+        logistics_shipment: logisticsData?.shipment || null,
+        logistics_storage: logisticsData?.storage || null,
         equipment_requirements: equipmentRequirements || null,
         email_template: emailTemplate || null,
         scope_template: scopeTemplate || null,


### PR DESCRIPTION
## Summary
- persist new shipment and storage logistics sections alongside core quote data
- load saved quotes with shipment and storage information restored

## Testing
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore" in supabase/functions/hubspot-search/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3752be908321aceb5501e9bb3243