### PR TITLE
Refactor equipment lists to chip-based UI

### DIFF
--- a/src/components/EquipmentRequired.tsx
+++ b/src/components/EquipmentRequired.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Plus, Minus, X } from 'lucide-react'
+import { Plus, X } from 'lucide-react'
 
 export interface EquipmentRequirements {
   crewSize: string
@@ -23,25 +23,31 @@ const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange })
 
   const handleArrayChange = (
     field: 'forkliftModels' | 'tractors' | 'trailers',
-    index: number,
-    value: string
+    items: string[]
   ) => {
-    const updated = [...data[field]]
-    updated[index] = value
-    handleFieldChange(field, updated)
+    handleFieldChange(field, items)
   }
 
-  const addItem = (field: 'forkliftModels' | 'tractors' | 'trailers') => {
-    handleFieldChange(field, [...data[field], ''])
+  const addItem = (
+    field: 'forkliftModels' | 'tractors' | 'trailers',
+    label: string
+  ) => {
+    const newItem = window.prompt(`Enter ${label.slice(0, -1)}`)
+    if (newItem && newItem.trim()) {
+      handleArrayChange(field, [...data[field], newItem.trim()])
+    }
   }
 
-  const removeItem = (field: 'forkliftModels' | 'tractors' | 'trailers', index: number) => {
+  const removeItem = (
+    field: 'forkliftModels' | 'tractors' | 'trailers',
+    index: number
+  ) => {
     const updated = data[field].filter((_, i) => i !== index)
-    handleFieldChange(field, updated)
+    handleArrayChange(field, updated)
   }
 
   const clearSection = () => {
-    onChange({ crewSize: '', forkliftModels: [''], tractors: [''], trailers: [''] })
+    onChange({ crewSize: '', forkliftModels: [], tractors: [], trailers: [] })
   }
 
   const renderList = (label: string, field: 'forkliftModels' | 'tractors' | 'trailers') => (
@@ -50,28 +56,25 @@ const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange })
         <label className="block text-sm font-medium text-white">{label}</label>
         <button
           type="button"
-          onClick={() => addItem(field)}
+          onClick={() => addItem(field, label)}
           className="p-1 bg-accent text-black rounded hover:bg-green-400 transition-colors"
         >
           <Plus className="w-4 h-4" />
         </button>
       </div>
-      <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
         {data[field].map((item, index) => (
-          <div key={index} className="flex items-center gap-2">
-            <input
-              type="text"
-              value={item}
-              onChange={(e) => handleArrayChange(field, index, e.target.value)}
-              className="flex-1 px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-              placeholder={`Enter ${label.toLowerCase().slice(0, -1)}`}
-            />
+          <div
+            key={index}
+            className="flex items-center bg-gray-900 border border-accent text-white rounded-full px-3 py-1"
+          >
+            <span className="mr-1">{item}</span>
             <button
               type="button"
               onClick={() => removeItem(field, index)}
-              className="p-1 bg-gray-900 border border-accent rounded hover:bg-gray-800"
+              className="p-0.5 rounded-full hover:bg-accent hover:text-black"
             >
-              <Minus className="w-4 h-4 text-white" />
+              <X className="w-3 h-3" />
             </button>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Render forklifts, tractors, and trailers as removable chips instead of input fields
- Add dialog-driven equipment entry via Add button and update array handlers
- Style chips with dark theme and green accent, adjust clear section handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore" and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3eb7381c8321bdd62c40952f6821