### PR TITLE
feat: show prefix '+' on equipment chips

### DIFF
--- a/src/components/EquipmentRequired.tsx
+++ b/src/components/EquipmentRequired.tsx
@@ -68,7 +68,7 @@ const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange })
             key={index}
             className="flex items-center bg-gray-900 border border-accent text-white rounded-full px-3 py-1"
           >
-            <span className="mr-1">{item}</span>
+            <span className="mr-1">+ {item}</span>
             <button
               type="button"
               onClick={() => removeItem(field, index)}


### PR DESCRIPTION
## Summary
- prepend a "+" to equipment requirement chips

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @ts-ignore usage and other type issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bf40222edc8321934e7a8b958289b7