### PR TITLE
feat: add predefined equipment options

### DIFF
--- a/src/components/EquipmentRequired.tsx
+++ b/src/components/EquipmentRequired.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Plus, X } from 'lucide-react'
+import { X } from 'lucide-react'
 
 export interface EquipmentRequirements {
   crewSize: string
@@ -12,6 +12,22 @@ interface EquipmentRequiredProps {
   data: EquipmentRequirements
   onChange: (data: EquipmentRequirements) => void
 }
+
+const forkliftOptions = [
+  'Forklift (5k)',
+  'Forklift (8k)',
+  'Forklift (15k)',
+  'Forklift (30k)',
+  'Forklift – Hoist 18/26',
+  'Versalift 25/35',
+  'Versalift 40/60',
+  'Versalift 60/80',
+  'Trilifter',
+]
+
+const tractorOptions = ['3-axle tractor', '4-axle tractor', 'Rollback']
+
+const trailerOptions = ['Dovetail', 'Flatbed', 'Lowboy', 'Step Deck']
 
 const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange }) => {
   const handleFieldChange = <K extends keyof EquipmentRequirements>(
@@ -28,56 +44,44 @@ const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange })
     handleFieldChange(field, items)
   }
 
-  const addItem = (
-    field: 'forkliftModels' | 'tractors' | 'trailers',
-    label: string
-  ) => {
-    const newItem = window.prompt(`Enter ${label.slice(0, -1)}`)
-    if (newItem && newItem.trim()) {
-      handleArrayChange(field, [...data[field], newItem.trim()])
-    }
-  }
-
-  const removeItem = (
-    field: 'forkliftModels' | 'tractors' | 'trailers',
-    index: number
-  ) => {
-    const updated = data[field].filter((_, i) => i !== index)
-    handleArrayChange(field, updated)
-  }
-
   const clearSection = () => {
     onChange({ crewSize: '', forkliftModels: [], tractors: [], trailers: [] })
   }
 
-  const renderList = (label: string, field: 'forkliftModels' | 'tractors' | 'trailers') => (
+  const renderOptionList = (
+    label: string,
+    field: 'forkliftModels' | 'tractors' | 'trailers',
+    options: string[]
+  ) => (
     <div>
-      <div className="flex items-center justify-between mb-2">
-        <label className="block text-sm font-medium text-white">{label}</label>
-        <button
-          type="button"
-          onClick={() => addItem(field, label)}
-          className="p-1 bg-accent text-black rounded hover:bg-green-400 transition-colors"
-        >
-          <Plus className="w-4 h-4" />
-        </button>
-      </div>
+      <label className="block text-sm font-medium text-white mb-2">{label}</label>
       <div className="flex flex-wrap gap-2">
-        {data[field].map((item, index) => (
-          <div
-            key={index}
-            className="flex items-center bg-gray-900 border border-accent text-white rounded-full px-3 py-1"
-          >
-            <span className="mr-1">+ {item}</span>
-            <button
-              type="button"
-              onClick={() => removeItem(field, index)}
-              className="p-0.5 rounded-full hover:bg-accent hover:text-black"
+        {options.map((option) => {
+          const checked = data[field].includes(option)
+          return (
+            <label
+              key={option}
+              className="flex items-center bg-gray-900 border border-accent text-white rounded-full px-3 py-1 space-x-2"
             >
-              <X className="w-3 h-3" />
-            </button>
-          </div>
-        ))}
+              <input
+                type="checkbox"
+                className="form-checkbox h-4 w-4 text-accent"
+                checked={checked}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    handleArrayChange(field, [...data[field], option])
+                  } else {
+                    handleArrayChange(
+                      field,
+                      data[field].filter((item) => item !== option)
+                    )
+                  }
+                }}
+              />
+              <span>{option}</span>
+            </label>
+          )
+        })}
       </div>
     </div>
   )
@@ -114,9 +118,9 @@ const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange })
         </select>
       </div>
 
-      {renderList('Forklift Models', 'forkliftModels')}
-      {renderList('Tractors', 'tractors')}
-      {renderList('Trailers', 'trailers')}
+      {renderOptionList('Forklift Models', 'forkliftModels', forkliftOptions)}
+      {renderOptionList('Tractors', 'tractors', tractorOptions)}
+      {renderOptionList('Trailers', 'trailers', trailerOptions)}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace manual equipment entry with selectable options for forklifts, tractors, and trailers
- provide checkbox UI for choosing required equipment

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: See log for ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf43407d4083219e3ffef0b4c3af37