### PR TITLE
feat: add quantity controls for equipment requirements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,9 +27,9 @@ const App: React.FC = () => {
   // State for equipment form
   const initialEquipmentRequirements: EquipmentRequirements = {
     crewSize: '',
-    forkliftModels: [''],
-    tractors: [''],
-    trailers: ['']
+    forklifts: [],
+    tractors: [],
+    trailers: []
   }
 
   const [equipmentData, setEquipmentData] = useState({

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -16,17 +16,33 @@ export const generateEmailTemplate = (
   const scopeOfWork = equipmentData.scopeOfWork || ''
 
   const crewSize = equipmentRequirements.crewSize || ''
-  const forklifts = (equipmentRequirements.forkliftModels || []).filter((f: string) => f)
-  const tractors = (equipmentRequirements.tractors || []).filter((t: string) => t)
-  const trailers = (equipmentRequirements.trailers || []).filter((t: string) => t)
+  const forklifts = (equipmentRequirements.forklifts || []).filter((f: any) => f.quantity > 0)
+  const tractors = (equipmentRequirements.tractors || []).filter((t: any) => t.quantity > 0)
+  const trailers = (equipmentRequirements.trailers || []).filter((t: any) => t.quantity > 0)
 
   const equipmentLines =
     crewSize || forklifts.length || tractors.length || trailers.length
       ? `EQUIPMENT REQUIREMENTS:\n${
           crewSize ? `• Crew Size: ${crewSize}\n` : ''
-        }${forklifts.length ? `• Forklifts: ${forklifts.join(', ')}\n` : ''}${
-          tractors.length ? `• Tractors: ${tractors.join(', ')}\n` : ''
-        }${trailers.length ? `• Trailers: ${trailers.join(', ')}\n` : ''}\n`
+        }${
+          forklifts.length
+            ? `• Forklifts: ${forklifts
+                .map((f: any) => `${f.quantity} x ${f.name}`)
+                .join(', ')}\n`
+            : ''
+        }${
+          tractors.length
+            ? `• Tractors: ${tractors
+                .map((t: any) => `${t.quantity} x ${t.name}`)
+                .join(', ')}\n`
+            : ''
+        }${
+          trailers.length
+            ? `• Trailers: ${trailers
+                .map((t: any) => `${t.quantity} x ${t.name}`)
+                .join(', ')}\n`
+            : ''
+        }\n`
       : ''
 
   const pickupAddress = logisticsData.pickupAddress || siteAddress
@@ -102,15 +118,21 @@ export const generateScopeTemplate = (
   const scopeOfWork = equipmentData.scopeOfWork || ''
 
   const crewSize = equipmentRequirements.crewSize || ''
-  const forklifts = (equipmentRequirements.forkliftModels || []).filter((f: string) => f)
-  const tractors = (equipmentRequirements.tractors || []).filter((t: string) => t)
-  const trailers = (equipmentRequirements.trailers || []).filter((t: string) => t)
+  const forklifts = (equipmentRequirements.forklifts || []).filter((f: any) => f.quantity > 0)
+  const tractors = (equipmentRequirements.tractors || []).filter((t: any) => t.quantity > 0)
+  const trailers = (equipmentRequirements.trailers || []).filter((t: any) => t.quantity > 0)
 
   const equipmentSummary = [
     crewSize ? `${crewSize} crew` : '',
-    forklifts.length ? `${forklifts.join(', ')} forklift(s)` : '',
-    tractors.length ? `${tractors.join(', ')} tractor(s)` : '',
-    trailers.length ? `${trailers.join(', ')} trailer(s)` : ''
+    forklifts.length
+      ? `${forklifts.map((f: any) => `${f.quantity} x ${f.name}`).join(', ')} forklift(s)`
+      : '',
+    tractors.length
+      ? `${tractors.map((t: any) => `${t.quantity} x ${t.name}`).join(', ')} tractor(s)`
+      : '',
+    trailers.length
+      ? `${trailers.map((t: any) => `${t.quantity} x ${t.name}`).join(', ')} trailer(s)`
+      : ''
   ]
     .filter(Boolean)
     .join(', ')

--- a/src/components/QuoteHistoryModal.tsx
+++ b/src/components/QuoteHistoryModal.tsx
@@ -161,7 +161,7 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
         const loadedRequirements =
           quote.equipment_requirements || {
             crewSize: '',
-            forkliftModels: [],
+            forklifts: [],
             tractors: [],
             trailers: []
           }

--- a/src/components/QuoteSaveManager.tsx
+++ b/src/components/QuoteSaveManager.tsx
@@ -154,7 +154,7 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
         const loadedRequirements =
           quote.equipment_requirements || {
             crewSize: '',
-            forkliftModels: [],
+            forklifts: [],
             tractors: [],
             trailers: []
           }


### PR DESCRIPTION
## Summary
- allow specifying multiple units of each equipment type
- show plus/minus quantity controls for forklifts, tractors and trailers
- update quote templates and loaders to support item quantities

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Use "@ts-expect-error" instead of "@ts-ignore")
- `npx eslint src/App.tsx src/components/EquipmentRequired.tsx src/components/PreviewTemplates.tsx src/components/QuoteSaveManager.tsx src/components/QuoteHistoryModal.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf4dff878c8321bdeeae2774d63580