### PR TITLE
Add shop location dropdown with default

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ const App: React.FC = () => {
     contactName: '',
     siteAddress: '',
     sitePhone: '',
-    shopLocation: '',
+    shopLocation: 'Shop',
     scopeOfWork: '',
     email: '',
     equipmentRequirements: initialEquipmentRequirements

--- a/src/components/ProjectDetails.tsx
+++ b/src/components/ProjectDetails.tsx
@@ -26,9 +26,10 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
   }
 
   const clearSection = () => {
-    ;(['projectName', 'companyName', 'contactName', 'siteAddress', 'sitePhone', 'shopLocation', 'scopeOfWork', 'email'] as (keyof ProjectDetailsData)[]).forEach(field => {
+    ;(['projectName', 'companyName', 'contactName', 'siteAddress', 'sitePhone', 'scopeOfWork', 'email'] as (keyof ProjectDetailsData)[]).forEach(field => {
       onChange(field, '')
     })
+    onChange('shopLocation', 'Shop')
   }
 
   return (
@@ -126,13 +127,15 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
           <MapPin className="w-4 h-4 inline mr-1" />
           Shop Location
         </label>
-        <input
-          type="text"
+        <select
           value={data.shopLocation}
           onChange={(e) => handleFieldChange('shopLocation', e.target.value)}
           className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-          placeholder="Enter shop location"
-        />
+        >
+          <option value="Shop">Shop</option>
+          <option value="Mukilteo">Mukilteo</option>
+          <option value="Fife">Fife</option>
+        </select>
       </div>
 
       <div>

--- a/src/components/QuoteHistoryModal.tsx
+++ b/src/components/QuoteHistoryModal.tsx
@@ -152,7 +152,7 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
           companyName: quote.company_name || '',
           contactName: quote.contact_name || '',
           sitePhone: quote.site_phone || '',
-          shopLocation: quote.shop_location || '',
+          shopLocation: quote.shop_location || 'Shop',
           siteAddress: quote.site_address || '',
           scopeOfWork: quote.scope_of_work || '',
           email: '',

--- a/src/components/QuoteSaveManager.tsx
+++ b/src/components/QuoteSaveManager.tsx
@@ -145,7 +145,7 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
           companyName: quote.company_name || '',
           contactName: quote.contact_name || '',
           sitePhone: quote.site_phone || '',
-          shopLocation: quote.shop_location || '',
+          shopLocation: quote.shop_location || 'Shop',
           siteAddress: quote.site_address || '',
           scopeOfWork: quote.scope_of_work || '',
           email: '',


### PR DESCRIPTION
## Summary
- Add shop location selector with Shop, Mukilteo, and Fife options
- Default shop location to "Shop" across app and quote loaders

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: @typescript-eslint errors in supabase functions)


------
https://chatgpt.com/codex/tasks/task_e_68bf54b4fe5c83218ab36acb71db0be4