### PR TITLE
Remove service type field

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,6 @@ const App: React.FC = () => {
     deliveryCity: '',
     deliveryState: '',
     deliveryZip: '',
-    serviceType: 'Standard Delivery',
     shipmentType: 'LTL',
     truckType: '',
     storageType: '',
@@ -462,21 +461,6 @@ const App: React.FC = () => {
                     />
                   </div>
                 </div>
-              </div>
-
-              {/* Service Type */}
-              <div>
-                <label className="block text-sm font-medium text-white mb-2">Service Type</label>
-                <select
-                  value={logisticsData.serviceType}
-                  onChange={(e) => handleLogisticsChange('serviceType', e.target.value)}
-                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                >
-                  <option value="Standard Delivery">Standard Delivery</option>
-                  <option value="White Glove">White Glove</option>
-                  <option value="Inside Delivery">Inside Delivery</option>
-                  <option value="Curbside">Curbside</option>
-                </select>
               </div>
 
               {/* Shipment Type */}

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -51,7 +51,6 @@ export const generateEmailTemplate = (
   const logisticsLines = [
     pickupAddress ? `• Pickup Location: ${pickupAddress}` : '',
     deliveryAddress ? `• Delivery Location: ${deliveryAddress}` : '',
-    logisticsData.serviceType ? `• Service Type: ${logisticsData.serviceType}` : '',
     logisticsData.shipmentType ? `• Shipment Type: ${logisticsData.shipmentType}` : '',
     logisticsData.truckType ? `• Truck Type: ${logisticsData.truckType}` : '',
     logisticsData.storageType

--- a/supabase/functions/ai-extract-project/index.ts
+++ b/supabase/functions/ai-extract-project/index.ts
@@ -49,7 +49,6 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "deliveryCity": "string",
     "deliveryState": "string",
     "deliveryZip": "string",
-    "serviceType": "string (Standard Delivery, White Glove, Inside Delivery, or Curbside)",
     "truckType": "string (Flatbed, Flatbed with tarp, Conestoga)"
   }
 }

--- a/supabase/functions/ai-extract-with-storage/index.ts
+++ b/supabase/functions/ai-extract-with-storage/index.ts
@@ -49,7 +49,6 @@ Return a JSON object with two main sections: "equipment" and "logistics". Struct
     "deliveryCity": "string",
     "deliveryState": "string",
     "deliveryZip": "string",
-    "serviceType": "string (Standard Delivery, White Glove, Inside Delivery, or Curbside)",
     "truckType": "string (Flatbed, Flatbed with tarp, Conestoga)"
   }
 }


### PR DESCRIPTION
## Summary
- remove service type option from logistics data and form
- drop service type lines from preview templates and AI extraction prompts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: errors in supabase/functions/hubspot-search/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bf548a297c83218f5b95b57e3aba41