### PR TITLE
feat: add editable clarifications sections with copy tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import ApiKeySetup from './components/ApiKeySetup'
 import ProjectDetails from './components/ProjectDetails'
 import { HubSpotContact } from './services/hubspotService'
 import EquipmentRequired, { EquipmentRequirements } from './components/EquipmentRequired'
+import ClarificationsSection from './components/ClarificationsSection'
 
 const App: React.FC = () => {
   // State for equipment form
@@ -584,6 +585,31 @@ const App: React.FC = () => {
           <p className="text-sm text-white">
             Templates are automatically populated with extracted data. Fields in brackets [ ] need manual completion.
           </p>
+        </div>
+
+        {/* Clarifications */}
+        <div className="mt-8 space-y-8">
+          <ClarificationsSection
+            title="Machinery Moving"
+            initialItems={[
+              'Any change to the job will require approval in writing prior to completion of work.',
+              'Customer is to supply clear pathway for all items to be loaded onto trailers',
+              'Quote is based on no site visit and is not responsible for cracks in pavement or other unforeseen causes to not be able to perform work'
+            ]}
+          />
+          <ClarificationsSection
+            title="Crane"
+            initialItems={[
+              'Crew to take half hour meal break between 4 - 5 hour start of shift in yard.',
+              'Customer may work crew through first meal break and pay missed meal charge of $175 per crew member.',
+              '60 ton boom truck quoted and 6 and 8 hour minimums. 8 hour quoted for budget.',
+              'Quoted straight time and portal to portal.',
+              'Overtime overtime to be charged $65/hour.',
+              'Straight time is the first 8 hours worked between 5am - 6pm Monday through Friday including travel and dismantle.',
+              'Customer may work crew through meal with signature on work ticket and pay missed meal charge of $175 per crew member per missed meal.',
+              'Mandatory missed meal charge at 10 hours from start of shift.'
+            ]}
+          />
         </div>
 
         {/* Modals */}

--- a/src/components/ClarificationsSection.tsx
+++ b/src/components/ClarificationsSection.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react'
+import { Copy, CheckCircle, Trash2, Plus } from 'lucide-react'
+
+interface ClarificationsSectionProps {
+  title: string
+  initialItems: string[]
+}
+
+interface ClarificationItem {
+  text: string
+  copied: boolean
+}
+
+const ClarificationsSection: React.FC<ClarificationsSectionProps> = ({ title, initialItems }) => {
+  const [items, setItems] = useState<ClarificationItem[]>(
+    initialItems.map(text => ({ text, copied: false }))
+  )
+
+  const handleTextChange = (index: number, value: string) => {
+    setItems(prev =>
+      prev.map((item, i) =>
+        i === index ? { ...item, text: value, copied: false } : item
+      )
+    )
+  }
+
+  const handleCopy = async (index: number) => {
+    try {
+      await navigator.clipboard.writeText(items[index].text)
+      setItems(prev =>
+        prev.map((item, i) => (i === index ? { ...item, copied: true } : item))
+      )
+    } catch (err) {
+      console.error('Failed to copy text', err)
+    }
+  }
+
+  const handleDelete = (index: number) => {
+    setItems(prev => prev.filter((_, i) => i !== index))
+  }
+
+  const handleAdd = () => {
+    setItems(prev => [...prev, { text: '', copied: false }])
+  }
+
+  return (
+    <div className="bg-gray-900 rounded-lg border-2 border-accent p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-bold text-white">{title}</h2>
+        <button
+          onClick={handleAdd}
+          className="flex items-center px-3 py-1 bg-accent text-black rounded-lg hover:bg-green-400 transition-colors"
+        >
+          <Plus className="w-4 h-4 mr-1" /> Add
+        </button>
+      </div>
+      <div className="space-y-2">
+        {items.map((item, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <input
+              type="text"
+              value={item.text}
+              onChange={(e) => handleTextChange(index, e.target.value)}
+              className="flex-1 px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm"
+              placeholder="Clarification"
+            />
+            <button
+              onClick={() => handleCopy(index)}
+              className="p-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors border border-accent"
+            >
+              {item.copied ? (
+                <CheckCircle className="w-4 h-4" />
+              ) : (
+                <Copy className="w-4 h-4" />
+              )}
+            </button>
+            <button
+              onClick={() => handleDelete(index)}
+              className="p-2 bg-red-600 text-white rounded-lg hover:bg-red-500 transition-colors"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default ClarificationsSection
+


### PR DESCRIPTION
## Summary
- add ClarificationsSection component to manage clarification items with copy, edit, add, and delete capabilities
- integrate Machinery Moving and Crane clarification sections at bottom of app

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors in supabase/functions/hubspot-search)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bf58b9fd8c8321bf8f4d7fc6a97e37