### PR TITLE
Remove default shipment type from scope template

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,7 @@ const App: React.FC = () => {
     deliveryCity: '',
     deliveryState: '',
     deliveryZip: '',
-    shipmentType: 'LTL',
+    shipmentType: '',
     truckType: '',
     storageType: '',
     storageSqFt: ''
@@ -178,7 +178,7 @@ const App: React.FC = () => {
     })
     setLogisticsData({
       truckType: '',
-      shipmentType: 'LTL',
+      shipmentType: '',
       storageType: '',
       storageSqFt: '',
       ...loadedLogisticsData

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -72,7 +72,7 @@ export class QuoteService {
         scope_of_work: equipmentData.scopeOfWork || null,
         logistics_data: {
           ...logisticsData,
-          shipmentType: logisticsData?.shipmentType || 'LTL',
+          shipmentType: logisticsData?.shipmentType || '',
           storageType: logisticsData?.storageType || '',
           storageSqFt: logisticsData?.storageSqFt || ''
         },


### PR DESCRIPTION
## Summary
- avoid inserting a default shipment type by initializing logistics shipmentType to an empty string
- ensure saved quotes don't assume LTL shipment by default

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 14 problems: @ts-expect-error, no-explicit-any, etc.)*
- `npx eslint src/App.tsx src/services/quoteService.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf58e0103883219fcb454abdc13aa2