### PR TITLE
refactor: use environment vars for supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Install dependencies:
 npm install
 ```
 
+Create a `.env` file in the project root with your Supabase credentials:
+
+```bash
+VITE_SUPABASE_URL=your-project-url
+VITE_SUPABASE_ANON_KEY=your-anon-key
+```
+
 Start the development server:
 
 ```bash

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://oorgoezqxexsewcwasvh.supabase.co'
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9vcmdvZXpxeGV4c2V3Y3dhc3ZoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI3MTU0NzUsImV4cCI6MjA2ODI5MTQ3NX0.PLGUswNkjeNbbOOEsD7MpLuCY0HSwUMAGO3Q-IPAfjw'
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 if (!supabaseUrl) {
   throw new Error('Missing VITE_SUPABASE_URL environment variable')
@@ -12,7 +12,7 @@ if (!supabaseAnonKey) {
   throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable')
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+export const supabase = createClient(supabaseUrl!, supabaseAnonKey!, {
   auth: {
     persistSession: true,
     autoRefreshToken: true,


### PR DESCRIPTION
## Summary
- load Supabase credentials exclusively from environment variables
- document required Supabase environment variables for local setup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore", Unexpected any, '_' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68c0396ca68c83219e52187368f13b68