### PR TITLE
chore: add explicit types for project data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect } from 'react'
 import {
   FileText,
@@ -21,13 +20,13 @@ import {
 import QuoteSaveManager from './components/QuoteSaveManager'
 import ApiKeySetup from './components/ApiKeySetup'
 import ClarificationsSection from './components/ClarificationsSection'
-import { HubSpotContact } from './services/hubspotService'
 import EquipmentForm from './components/EquipmentForm'
 import LogisticsForm from './components/LogisticsForm'
 import useEquipmentForm from './hooks/useEquipmentForm'
 import useLogisticsForm from './hooks/useLogisticsForm'
 import useModals from './hooks/useModals'
 import { EquipmentRequirements } from './components/EquipmentRequired'
+import { EquipmentData, LogisticsData } from './types'
 
 const App: React.FC = () => {
   const {
@@ -80,7 +79,10 @@ const App: React.FC = () => {
   }, [equipmentData.siteAddress])
 
 
-  const handleAIExtraction = (extractedEquipmentData: any, extractedLogisticsData: any) => {
+  const handleAIExtraction = (
+    extractedEquipmentData: Partial<EquipmentData>,
+    extractedLogisticsData: Partial<LogisticsData>
+  ) => {
     if (extractedEquipmentData) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { projectDescription, ...rest } = extractedEquipmentData
@@ -92,8 +94,8 @@ const App: React.FC = () => {
   }
 
   const handleLoadQuote = (
-    loadedEquipmentData: any,
-    loadedLogisticsData: any,
+    loadedEquipmentData: EquipmentData,
+    loadedLogisticsData: LogisticsData,
     loadedEquipmentRequirements?: EquipmentRequirements
   ) => {
     setEquipmentData({

--- a/src/components/AIExtractorModal.tsx
+++ b/src/components/AIExtractorModal.tsx
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState } from 'react'
 import { Bot, Send, Loader, X, AlertCircle, CheckCircle } from 'lucide-react'
 import { useApiKey } from '../hooks/useApiKey'
 import { AIExtractionService } from '../services/aiExtractionService'
+import { EquipmentData, LogisticsData } from '../types'
 
 interface Message {
   id: string
@@ -14,7 +14,10 @@ interface Message {
 interface AIExtractorModalProps {
   isOpen: boolean
   onClose: () => void
-  onExtract: (equipmentData: any, logisticsData: any) => void
+  onExtract: (
+    equipmentData: Partial<EquipmentData>,
+    logisticsData: Partial<LogisticsData>
+  ) => void
   sessionId: string
 }
 
@@ -76,7 +79,7 @@ const AIExtractorModal: React.FC<AIExtractorModalProps> = ({ isOpen, onClose, on
       } else {
         addMessage('error', result.error || 'Extraction failed')
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Extraction error:', error)
       addMessage('error', `Sorry, there was an error: ${error instanceof Error ? error.message : 'Unknown error'}`)
     } finally {

--- a/src/components/EquipmentForm.tsx
+++ b/src/components/EquipmentForm.tsx
@@ -3,9 +3,10 @@ import { FileText } from 'lucide-react';
 import ProjectDetails from './ProjectDetails';
 import EquipmentRequired, { EquipmentRequirements } from './EquipmentRequired';
 import { HubSpotContact } from '../services/hubspotService';
+import { EquipmentData } from '../types'
 
 interface EquipmentFormProps {
-  data: any;
+  data: EquipmentData;
   onFieldChange: (field: string, value: string) => void;
   onRequirementsChange: (data: EquipmentRequirements) => void;
   onSelectContact: (contact: HubSpotContact) => void;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { createClient } from '@supabase/supabase-js'
+import { SupabaseTempQuoteResponse } from '../types'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
@@ -24,11 +24,4 @@ export const supabase = createClient(supabaseUrl!, supabaseAnonKey!, {
   }
 })
 
-export interface TempQuoteData {
-  id?: string
-  session_id: string
-  equipment_data?: any
-  logistics_data?: any
-  created_at?: string
-  updated_at?: string
-}
+export type TempQuoteData = SupabaseTempQuoteResponse

--- a/src/services/aiExtractionService.ts
+++ b/src/services/aiExtractionService.ts
@@ -1,18 +1,14 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ApiKeyService } from './apiKeyService'
-
-interface ExtractionResult {
-  equipmentData?: any
-  logisticsData?: any
-  success: boolean
-  error?: string
-}
+import { ExtractionResult } from '../types'
 
 export class AIExtractionService {
   private static readonly SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || ''
   private static readonly SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || ''
 
-  static async extractProjectInfo(text: string, sessionId: string): Promise<ExtractionResult> {
+  static async extractProjectInfo(
+    text: string,
+    sessionId: string
+  ): Promise<ExtractionResult> {
     try {
       // Check if environment variables are available
       if (!this.SUPABASE_URL || !this.SUPABASE_ANON_KEY) {
@@ -52,8 +48,8 @@ export class AIExtractionService {
         throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`)
       }
 
-      const result = await response.json()
-      
+      const result: ExtractionResult = await response.json()
+
       if (!result.success) {
         throw new Error(result.error || 'Extraction failed')
       }

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -1,5 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { supabase } from '../lib/supabase'
+import { EquipmentData, LogisticsData } from '../types'
+import { EquipmentRequirements } from '../components/EquipmentRequired'
 
 export interface QuoteListItem {
   id: string
@@ -21,10 +22,10 @@ export interface SavedQuote {
   shop_location: string | null
   site_address: string | null
   scope_of_work: string | null
-  logistics_data: any
-  logistics_shipment: any
-  logistics_storage: any
-  equipment_requirements: any
+  logistics_data: LogisticsData | null
+  logistics_shipment: Record<string, unknown> | null
+  logistics_storage: Record<string, unknown> | null
+  equipment_requirements: EquipmentRequirements | null
   email_template: string | null
   scope_template: string | null
   created_at: string
@@ -53,9 +54,9 @@ export class QuoteService {
 
   static async saveQuote(
     quoteNumber: string,
-    equipmentData: any,
-    logisticsData: any,
-    equipmentRequirements: any,
+    equipmentData: EquipmentData,
+    logisticsData: LogisticsData,
+    equipmentRequirements: EquipmentRequirements,
     emailTemplate?: string,
     scopeTemplate?: string,
     existingId?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,56 @@
+import { EquipmentRequirements } from './components/EquipmentRequired'
+
+export interface EquipmentData {
+  projectName?: string
+  companyName?: string
+  contactName?: string
+  siteAddress?: string
+  sitePhone?: string
+  shopLocation?: string
+  scopeOfWork?: string
+  email?: string
+  equipmentRequirements: EquipmentRequirements
+}
+
+export interface LogisticsPiece {
+  description: string
+  quantity: number
+  length: string
+  width: string
+  height: string
+  weight: string
+}
+
+export interface LogisticsData {
+  pieces?: LogisticsPiece[]
+  pickupAddress?: string
+  pickupCity?: string
+  pickupState?: string
+  pickupZip?: string
+  deliveryAddress?: string
+  deliveryCity?: string
+  deliveryState?: string
+  deliveryZip?: string
+  shipmentType?: string
+  truckType?: string
+  storageType?: string
+  storageSqFt?: string
+  shipment?: Record<string, unknown> | null
+  storage?: Record<string, unknown> | null
+}
+
+export interface ExtractionResult {
+  equipmentData?: Partial<EquipmentData>
+  logisticsData?: Partial<LogisticsData>
+  success: boolean
+  error?: string
+}
+
+export interface SupabaseTempQuoteResponse {
+  id?: string
+  session_id: string
+  equipment_data?: EquipmentData
+  logistics_data?: LogisticsData
+  created_at?: string
+  updated_at?: string
+}


### PR DESCRIPTION
## Summary
- re-enable `@typescript-eslint/no-explicit-any` and use shared interfaces for equipment and logistics data
- type AI extraction service, Supabase client, and quote service responses
- clean up HubSpot search edge function to avoid `any`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c0431cd7488321afac573e2250a06b