### PR TITLE
Add unit tests and configure vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node --test"
+    "test": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.51.0",
@@ -32,7 +32,11 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^15.0.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jsdom": "^24.0.0"
   },
   "description": "Job_quote",
   "main": "eslint.config.js",

--- a/tests/AIExtractorModal.test.tsx
+++ b/tests/AIExtractorModal.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+
+vi.mock('../src/hooks/useApiKey', () => ({
+  useApiKey: () => ({ hasApiKey: true, loading: false, error: null })
+}))
+
+vi.mock('../src/services/aiExtractionService', () => ({
+  AIExtractionService: { extractProjectInfo: vi.fn() }
+}))
+
+import AIExtractorModal from '../src/components/AIExtractorModal'
+import { AIExtractionService } from '../src/services/aiExtractionService'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('AIExtractorModal', () => {
+  it('returns null when closed', () => {
+    const { container } = render(
+      <AIExtractorModal isOpen={false} onClose={() => {}} onExtract={() => {}} sessionId="s1" />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows ready state when open', () => {
+    render(
+      <AIExtractorModal isOpen={true} onClose={() => {}} onExtract={() => {}} sessionId="s1" />
+    )
+    expect(screen.getByText('Ready to extract')).toBeInTheDocument()
+  })
+
+  it('calls onExtract after successful extraction', async () => {
+    ;(AIExtractionService.extractProjectInfo as unknown as vi.Mock).mockResolvedValue({
+      success: true,
+      equipmentData: { projectName: 'P' },
+      logisticsData: { pickupAddress: 'A' }
+    })
+
+    const onExtract = vi.fn()
+    render(
+      <AIExtractorModal isOpen={true} onClose={() => {}} onExtract={onExtract} sessionId="s1" />
+    )
+
+    const textarea = screen.getByPlaceholderText(/Paste your email/i)
+    fireEvent.change(textarea, { target: { value: 'sample text' } })
+
+    const button = screen.getByRole('button', { name: /Extract Info/i })
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(AIExtractionService.extractProjectInfo).toHaveBeenCalled()
+      expect(onExtract).toHaveBeenCalledWith({ projectName: 'P' }, { pickupAddress: 'A' })
+    })
+  })
+})

--- a/tests/apiKeyService.test.ts
+++ b/tests/apiKeyService.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../src/lib/supabase', () => ({
+  supabase: { from: vi.fn() }
+}))
+
+vi.mock('../src/lib/encryption', () => ({
+  encrypt: vi.fn(async (t: string) => `enc-${t}`),
+  decrypt: vi.fn(async (t: string) => t.replace('enc-', ''))
+}))
+
+import { ApiKeyService } from '../src/services/apiKeyService'
+import { supabase } from '../src/lib/supabase'
+import { encrypt, decrypt } from '../src/lib/encryption'
+
+const fromMock = supabase.from as unknown as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ApiKeyService', () => {
+  it('retrieves and decrypts api key', async () => {
+    const singleMock = vi.fn().mockResolvedValue({ data: { encrypted_key: 'enc-secret' }, error: null })
+    const eqMock = vi.fn().mockReturnValue({ single: singleMock })
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock })
+    ;(fromMock as any).mockReturnValue({ select: selectMock })
+
+    const key = await ApiKeyService.getApiKey()
+
+    expect(decrypt).toHaveBeenCalledWith('enc-secret')
+    expect(key).toBe('secret')
+  })
+
+  it('encrypts and saves api key', async () => {
+    const upsertMock = vi.fn().mockResolvedValue({ error: null })
+    ;(fromMock as any).mockReturnValue({ upsert: upsertMock })
+
+    const result = await ApiKeyService.saveApiKey('secret')
+
+    expect(encrypt).toHaveBeenCalledWith('secret')
+    expect(upsertMock).toHaveBeenCalled()
+    expect(result).toBe(true)
+  })
+
+  it('checks if api key exists', async () => {
+    vi.spyOn(ApiKeyService, 'getApiKey').mockResolvedValue('abc')
+    const result = await ApiKeyService.hasApiKey()
+    expect(result).toBe(true)
+  })
+})

--- a/tests/quoteService.test.ts
+++ b/tests/quoteService.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../src/lib/supabase', () => ({
+  supabase: { from: vi.fn() }
+}))
+
+import { QuoteService } from '../src/services/quoteService'
+import type { EquipmentData, LogisticsData } from '../src/types'
+import { EquipmentRequirements } from '../src/components/EquipmentRequired'
+import { supabase } from '../src/lib/supabase'
+
+const fromMock = supabase.from as unknown as ReturnType<typeof vi.fn>
+
+const equipmentData: EquipmentData = {
+  projectName: 'Project',
+  companyName: 'Company',
+  contactName: 'Contact',
+  siteAddress: '',
+  sitePhone: '',
+  shopLocation: '',
+  scopeOfWork: '',
+  email: '',
+  equipmentRequirements: { crewSize: '', forklifts: [], tractors: [], trailers: [] } as EquipmentRequirements
+}
+
+const logisticsData: LogisticsData = {
+  shipmentType: '',
+  storageType: '',
+  storageSqFt: '',
+  shipment: null,
+  storage: null
+}
+
+const equipmentRequirements: EquipmentRequirements = { crewSize: '', forklifts: [], tractors: [], trailers: [] }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('QuoteService', () => {
+  it('generates quote number with project prefix', () => {
+    const quoteNumber = QuoteService.generateQuoteNumber('My Project')
+    expect(quoteNumber.startsWith('MYPR-')).toBe(true)
+  })
+
+  it('saves quote successfully', async () => {
+    const singleMock = vi.fn().mockResolvedValue({ data: { id: '123' }, error: null })
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock })
+    const insertMock = vi.fn().mockReturnValue({ select: selectMock })
+    ;(fromMock as any).mockReturnValue({ insert: insertMock })
+
+    const result = await QuoteService.saveQuote('Q1', equipmentData, logisticsData, equipmentRequirements)
+
+    expect(insertMock).toHaveBeenCalled()
+    expect(result).toEqual({ success: true, id: '123' })
+  })
+
+  it('returns error when supabase fails to save quote', async () => {
+    const singleMock = vi.fn().mockResolvedValue({ data: null, error: { message: 'fail' } })
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock })
+    const insertMock = vi.fn().mockReturnValue({ select: selectMock })
+    ;(fromMock as any).mockReturnValue({ insert: insertMock })
+
+    const result = await QuoteService.saveQuote('Q1', equipmentData, logisticsData, equipmentRequirements)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('fail')
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,4 +18,10 @@ export default defineConfig({
       },
     },
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './tests/setup.ts',
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx']
+  }
 });


### PR DESCRIPTION
## Summary
- add vitest-based unit tests for quoteService and apiKeyService
- cover AIExtractorModal with interaction tests
- configure Vitest in package and Vite config

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c044a5d7e88321a8b770484b28013f