### PR TITLE
feat: add form validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,10 @@
         "lucide-react": "^0.344.0",
         "node-fetch": "^3.3.2",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-hook-form": "^7.50.0",
+        "yup": "^1.3.0",
+        "@hookform/resolvers": "^3.3.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "lucide-react": "^0.344.0",
     "node-fetch": "^3.3.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.50.0",
+    "yup": "^1.3.0",
+    "@hookform/resolvers": "^3.3.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,9 @@ import useLogisticsForm from './hooks/useLogisticsForm'
 import useModals from './hooks/useModals'
 import { EquipmentRequirements } from './components/EquipmentRequired'
 import { EquipmentData, LogisticsData } from './types'
+import { useForm } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { equipmentSchema, logisticsSchema } from './lib/validation'
 
 const App: React.FC = () => {
   const {
@@ -51,6 +54,32 @@ const App: React.FC = () => {
     togglePieceSelection,
     deleteSelectedPieces
   } = useLogisticsForm()
+
+  const equipmentForm = useForm<EquipmentData>({
+    resolver: yupResolver(equipmentSchema),
+    defaultValues: equipmentData,
+    mode: 'onBlur'
+  })
+
+  const logisticsForm = useForm<LogisticsData>({
+    resolver: yupResolver(logisticsSchema),
+    defaultValues: logisticsData,
+    mode: 'onBlur'
+  })
+
+  useEffect(() => {
+    equipmentForm.reset(equipmentData)
+  }, [equipmentData])
+
+  useEffect(() => {
+    logisticsForm.reset(logisticsData)
+  }, [logisticsData])
+
+  const validateForms = async () => {
+    const eqValid = await equipmentForm.trigger()
+    const lgValid = await logisticsForm.trigger()
+    return eqValid && lgValid
+  }
 
   const {
     showAIExtractor,
@@ -201,6 +230,8 @@ const App: React.FC = () => {
             onFieldChange={handleEquipmentChange}
             onRequirementsChange={handleEquipmentRequirementsChange}
             onSelectContact={handleSelectHubSpotContact}
+            register={equipmentForm.register}
+            errors={equipmentForm.formState.errors}
           />
 
           {/* Logistics Quote Form */}
@@ -213,6 +244,8 @@ const App: React.FC = () => {
             removePiece={removePiece}
             togglePieceSelection={togglePieceSelection}
             deleteSelectedPieces={deleteSelectedPieces}
+            register={logisticsForm.register}
+            errors={logisticsForm.formState.errors}
           />
         </div>
 
@@ -323,6 +356,7 @@ const App: React.FC = () => {
           isOpen={showHistory}
           onClose={closeHistory}
           onLoadQuote={handleLoadQuote}
+          onValidate={validateForms}
         />
 
         {showApiKeySetup && (

--- a/src/components/EquipmentForm.tsx
+++ b/src/components/EquipmentForm.tsx
@@ -1,22 +1,27 @@
-import React from 'react';
-import { FileText } from 'lucide-react';
-import ProjectDetails from './ProjectDetails';
-import EquipmentRequired, { EquipmentRequirements } from './EquipmentRequired';
-import { HubSpotContact } from '../services/hubspotService';
+import React from 'react'
+import { FileText } from 'lucide-react'
+import ProjectDetails from './ProjectDetails'
+import EquipmentRequired, { EquipmentRequirements } from './EquipmentRequired'
+import { HubSpotContact } from '../services/hubspotService'
 import { EquipmentData } from '../types'
+import { UseFormRegister, FieldErrors } from 'react-hook-form'
 
 interface EquipmentFormProps {
   data: EquipmentData;
   onFieldChange: (field: string, value: string) => void;
   onRequirementsChange: (data: EquipmentRequirements) => void;
   onSelectContact: (contact: HubSpotContact) => void;
+  register: UseFormRegister<EquipmentData>;
+  errors: FieldErrors<EquipmentData>;
 }
 
 const EquipmentForm: React.FC<EquipmentFormProps> = ({
   data,
   onFieldChange,
   onRequirementsChange,
-  onSelectContact
+  onSelectContact,
+  register,
+  errors
 }) => {
   return (
     <div className="bg-gray-900 rounded-lg border-2 border-accent p-6">
@@ -28,6 +33,8 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({
         data={data}
         onChange={onFieldChange}
         onSelectContact={onSelectContact}
+        register={register}
+        errors={errors}
       />
       <EquipmentRequired
         data={data.equipmentRequirements}

--- a/src/components/LogisticsForm.tsx
+++ b/src/components/LogisticsForm.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { Truck, Package, Plus, Minus, Trash2 } from 'lucide-react';
+import React from 'react'
+import { Truck, Package, Plus, Minus, Trash2 } from 'lucide-react'
+import { UseFormRegister, FieldErrors } from 'react-hook-form'
 
 interface Piece {
   description: string;
@@ -39,6 +40,8 @@ interface LogisticsFormProps {
   removePiece: (index: number) => void;
   togglePieceSelection: (index: number) => void;
   deleteSelectedPieces: () => void;
+  register: UseFormRegister<LogisticsData>;
+  errors: FieldErrors<LogisticsData>;
 }
 
 const LogisticsForm: React.FC<LogisticsFormProps> = ({
@@ -49,7 +52,9 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
   addPiece,
   removePiece,
   togglePieceSelection,
-  deleteSelectedPieces
+  deleteSelectedPieces,
+  register,
+  errors
 }) => {
   return (
     <div className="bg-gray-900 rounded-lg border-2 border-accent p-6">
@@ -97,24 +102,50 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
                   />
                 </div>
                 <div className="col-span-4">
-                  <input
-                    type="text"
-                    value={piece.description}
-                    onChange={(e) => onPieceChange(index, 'description', e.target.value)}
-                    className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm"
-                    placeholder="Description"
-                  />
+                  {(() => {
+                    const field = register(`pieces.${index}.description` as const)
+                    return (
+                      <>
+                        <input
+                          type="text"
+                          value={piece.description}
+                          onChange={(e) => {
+                            field.onChange(e)
+                            onPieceChange(index, 'description', e.target.value)
+                          }}
+                          className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm"
+                          placeholder="Description"
+                        />
+                        {errors.pieces?.[index]?.description && (
+                          <p className="text-red-500 text-xs mt-1">{String(errors.pieces[index]?.description?.message)}</p>
+                        )}
+                      </>
+                    )
+                  })()}
                 </div>
                 <div className="col-span-1">
-                  <input
-                    type="number"
-                    value={piece.quantity}
-                    onChange={(e) => onPieceChange(index, 'quantity', parseInt(e.target.value) || 1)}
-                    className="w-16 px-2 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm text-center"
-                    placeholder="Qty"
-                    min="1"
-                    max="99"
-                  />
+                  {(() => {
+                    const field = register(`pieces.${index}.quantity` as const)
+                    return (
+                      <>
+                        <input
+                          type="number"
+                          value={piece.quantity}
+                          onChange={(e) => {
+                            field.onChange(e)
+                            onPieceChange(index, 'quantity', parseInt(e.target.value) || 1)
+                          }}
+                          className="w-16 px-2 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm text-center"
+                          placeholder="Qty"
+                          min="1"
+                          max="99"
+                        />
+                        {errors.pieces?.[index]?.quantity && (
+                          <p className="text-red-500 text-xs mt-1">{String(errors.pieces[index]?.quantity?.message)}</p>
+                        )}
+                      </>
+                    )
+                  })()}
                 </div>
                 <div className="col-span-1">
                   <input
@@ -144,13 +175,26 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
                   />
                 </div>
                 <div className="col-span-2">
-                  <input
-                    type="text"
-                    value={piece.weight}
-                    onChange={(e) => onPieceChange(index, 'weight', e.target.value)}
-                    className="w-full px-2 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm"
-                    placeholder="Weight (lbs)"
-                  />
+                  {(() => {
+                    const field = register(`pieces.${index}.weight` as const)
+                    return (
+                      <>
+                        <input
+                          type="text"
+                          value={piece.weight}
+                          onChange={(e) => {
+                            field.onChange(e)
+                            onPieceChange(index, 'weight', e.target.value)
+                          }}
+                          className="w-full px-2 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm"
+                          placeholder="Weight (lbs)"
+                        />
+                        {errors.pieces?.[index]?.weight && (
+                          <p className="text-red-500 text-xs mt-1">{String(errors.pieces[index]?.weight?.message)}</p>
+                        )}
+                      </>
+                    )
+                  })()}
                 </div>
                 <div className="col-span-1">
                   {data.pieces.length > 1 && (
@@ -171,35 +215,87 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
         <div>
           <label className="block text-sm font-medium text-white mb-2">Pickup Location</label>
           <div className="space-y-3">
-            <input
-              type="text"
-              value={data.pickupAddress}
-              onChange={(e) => onFieldChange('pickupAddress', e.target.value)}
-              className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-              placeholder="Pickup address"
-            />
+            {(() => {
+              const field = register('pickupAddress')
+              return (
+                <>
+                  <input
+                    type="text"
+                    value={data.pickupAddress}
+                    onChange={(e) => {
+                      field.onChange(e)
+                      onFieldChange('pickupAddress', e.target.value)
+                    }}
+                    className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                    placeholder="Pickup address"
+                  />
+                  {errors.pickupAddress && (
+                    <p className="text-red-500 text-xs mt-1">{String(errors.pickupAddress.message)}</p>
+                  )}
+                </>
+              )
+            })()}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-              <input
-                type="text"
-                value={data.pickupCity}
-                onChange={(e) => onFieldChange('pickupCity', e.target.value)}
-                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                placeholder="City"
-              />
-              <input
-                type="text"
-                value={data.pickupState}
-                onChange={(e) => onFieldChange('pickupState', e.target.value)}
-                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                placeholder="State"
-              />
-              <input
-                type="text"
-                value={data.pickupZip}
-                onChange={(e) => onFieldChange('pickupZip', e.target.value)}
-                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                placeholder="Zip"
-              />
+              {(() => {
+                const field = register('pickupCity')
+                return (
+                  <>
+                    <input
+                      type="text"
+                      value={data.pickupCity}
+                      onChange={(e) => {
+                        field.onChange(e)
+                        onFieldChange('pickupCity', e.target.value)
+                      }}
+                      className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                      placeholder="City"
+                    />
+                    {errors.pickupCity && (
+                      <p className="text-red-500 text-xs mt-1">{String(errors.pickupCity.message)}</p>
+                    )}
+                  </>
+                )
+              })()}
+              {(() => {
+                const field = register('pickupState')
+                return (
+                  <>
+                    <input
+                      type="text"
+                      value={data.pickupState}
+                      onChange={(e) => {
+                        field.onChange(e)
+                        onFieldChange('pickupState', e.target.value)
+                      }}
+                      className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                      placeholder="State"
+                    />
+                    {errors.pickupState && (
+                      <p className="text-red-500 text-xs mt-1">{String(errors.pickupState.message)}</p>
+                    )}
+                  </>
+                )
+              })()}
+              {(() => {
+                const field = register('pickupZip')
+                return (
+                  <>
+                    <input
+                      type="text"
+                      value={data.pickupZip}
+                      onChange={(e) => {
+                        field.onChange(e)
+                        onFieldChange('pickupZip', e.target.value)
+                      }}
+                      className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                      placeholder="Zip"
+                    />
+                    {errors.pickupZip && (
+                      <p className="text-red-500 text-xs mt-1">{String(errors.pickupZip.message)}</p>
+                    )}
+                  </>
+                )
+              })()}
             </div>
           </div>
         </div>
@@ -208,35 +304,87 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
         <div>
           <label className="block text-sm font-medium text-white mb-2">Delivery Location</label>
           <div className="space-y-3">
-            <input
-              type="text"
-              value={data.deliveryAddress}
-              onChange={(e) => onFieldChange('deliveryAddress', e.target.value)}
-              className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-              placeholder="Delivery address"
-            />
+            {(() => {
+              const field = register('deliveryAddress')
+              return (
+                <>
+                  <input
+                    type="text"
+                    value={data.deliveryAddress}
+                    onChange={(e) => {
+                      field.onChange(e)
+                      onFieldChange('deliveryAddress', e.target.value)
+                    }}
+                    className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                    placeholder="Delivery address"
+                  />
+                  {errors.deliveryAddress && (
+                    <p className="text-red-500 text-xs mt-1">{String(errors.deliveryAddress.message)}</p>
+                  )}
+                </>
+              )
+            })()}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-              <input
-                type="text"
-                value={data.deliveryCity}
-                onChange={(e) => onFieldChange('deliveryCity', e.target.value)}
-                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                placeholder="City"
-              />
-              <input
-                type="text"
-                value={data.deliveryState}
-                onChange={(e) => onFieldChange('deliveryState', e.target.value)}
-                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                placeholder="State"
-              />
-              <input
-                type="text"
-                value={data.deliveryZip}
-                onChange={(e) => onFieldChange('deliveryZip', e.target.value)}
-                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                placeholder="Zip"
-              />
+              {(() => {
+                const field = register('deliveryCity')
+                return (
+                  <>
+                    <input
+                      type="text"
+                      value={data.deliveryCity}
+                      onChange={(e) => {
+                        field.onChange(e)
+                        onFieldChange('deliveryCity', e.target.value)
+                      }}
+                      className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                      placeholder="City"
+                    />
+                    {errors.deliveryCity && (
+                      <p className="text-red-500 text-xs mt-1">{String(errors.deliveryCity.message)}</p>
+                    )}
+                  </>
+                )
+              })()}
+              {(() => {
+                const field = register('deliveryState')
+                return (
+                  <>
+                    <input
+                      type="text"
+                      value={data.deliveryState}
+                      onChange={(e) => {
+                        field.onChange(e)
+                        onFieldChange('deliveryState', e.target.value)
+                      }}
+                      className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                      placeholder="State"
+                    />
+                    {errors.deliveryState && (
+                      <p className="text-red-500 text-xs mt-1">{String(errors.deliveryState.message)}</p>
+                    )}
+                  </>
+                )
+              })()}
+              {(() => {
+                const field = register('deliveryZip')
+                return (
+                  <>
+                    <input
+                      type="text"
+                      value={data.deliveryZip}
+                      onChange={(e) => {
+                        field.onChange(e)
+                        onFieldChange('deliveryZip', e.target.value)
+                      }}
+                      className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                      placeholder="Zip"
+                    />
+                    {errors.deliveryZip && (
+                      <p className="text-red-500 text-xs mt-1">{String(errors.deliveryZip.message)}</p>
+                    )}
+                  </>
+                )
+              })()}
             </div>
           </div>
         </div>
@@ -244,29 +392,55 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
         {/* Shipment Type */}
         <div>
           <label className="block text-sm font-medium text-white mb-2">Shipment Type</label>
-          <select
-            value={data.shipmentType}
-            onChange={(e) => onFieldChange('shipmentType', e.target.value)}
-            className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-          >
-            <option value="LTL">LTL</option>
-            <option value="FTL">FTL</option>
-          </select>
+          {(() => {
+            const field = register('shipmentType')
+            return (
+              <>
+                <select
+                  value={data.shipmentType}
+                  onChange={(e) => {
+                    field.onChange(e)
+                    onFieldChange('shipmentType', e.target.value)
+                  }}
+                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                >
+                  <option value="LTL">LTL</option>
+                  <option value="FTL">FTL</option>
+                </select>
+                {errors.shipmentType && (
+                  <p className="text-red-500 text-xs mt-1">{String(errors.shipmentType.message)}</p>
+                )}
+              </>
+            )
+          })()}
         </div>
 
         {/* Truck Type Requested */}
         <div>
           <label className="block text-sm font-medium text-white mb-2">Truck Type Requested</label>
-          <select
-            value={data.truckType}
-            onChange={(e) => onFieldChange('truckType', e.target.value)}
-            className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-          >
-            <option value="">Select truck type</option>
-            <option value="Flatbed">Flatbed</option>
-            <option value="Flatbed with tarp">Flatbed with tarp</option>
-            <option value="Conestoga">Conestoga</option>
-          </select>
+          {(() => {
+            const field = register('truckType')
+            return (
+              <>
+                <select
+                  value={data.truckType}
+                  onChange={(e) => {
+                    field.onChange(e)
+                    onFieldChange('truckType', e.target.value)
+                  }}
+                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                >
+                  <option value="">Select truck type</option>
+                  <option value="Flatbed">Flatbed</option>
+                  <option value="Flatbed with tarp">Flatbed with tarp</option>
+                  <option value="Conestoga">Conestoga</option>
+                </select>
+                {errors.truckType && (
+                  <p className="text-red-500 text-xs mt-1">{String(errors.truckType.message)}</p>
+                )}
+              </>
+            )
+          })()}
         </div>
 
         {/* Storage Requirements */}

--- a/src/components/ProjectDetails.tsx
+++ b/src/components/ProjectDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FileText, Building, User, Phone, MapPin, ClipboardList, X } from 'lucide-react'
 import HubSpotContactSearch from './HubSpotContactSearch'
 import { HubSpotContact } from '../services/hubspotService'
+import { UseFormRegister, FieldErrors } from 'react-hook-form'
 
 export interface ProjectDetailsData {
   projectName: string
@@ -18,9 +19,11 @@ interface ProjectDetailsProps {
   data: ProjectDetailsData
   onChange: (field: keyof ProjectDetailsData, value: string) => void
   onSelectContact: (contact: HubSpotContact) => void
+  register: UseFormRegister<ProjectDetailsData>
+  errors: FieldErrors<ProjectDetailsData>
 }
 
-const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelectContact }) => {
+const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelectContact, register, errors }) => {
   const handleFieldChange = (field: keyof ProjectDetailsData, value: string) => {
     onChange(field, value)
   }
@@ -54,13 +57,26 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
             <FileText className="w-4 h-4 inline mr-1" />
             Project Name
           </label>
-          <input
-            type="text"
-            value={data.projectName}
-            onChange={(e) => handleFieldChange('projectName', e.target.value)}
-            className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-            placeholder="Enter project name"
-          />
+          {(() => {
+            const field = register('projectName')
+            return (
+              <>
+                <input
+                  type="text"
+                  value={data.projectName}
+                  onChange={(e) => {
+                    field.onChange(e)
+                    handleFieldChange('projectName', e.target.value)
+                  }}
+                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                  placeholder="Enter project name"
+                />
+                {errors.projectName && (
+                  <p className="text-red-500 text-xs mt-1">{String(errors.projectName.message)}</p>
+                )}
+              </>
+            )
+          })()}
         </div>
 
         <div>
@@ -68,13 +84,26 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
             <Building className="w-4 h-4 inline mr-1" />
             Company Name
           </label>
-          <input
-            type="text"
-            value={data.companyName}
-            onChange={(e) => handleFieldChange('companyName', e.target.value)}
-            className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-            placeholder="Enter company name"
-          />
+          {(() => {
+            const field = register('companyName')
+            return (
+              <>
+                <input
+                  type="text"
+                  value={data.companyName}
+                  onChange={(e) => {
+                    field.onChange(e)
+                    handleFieldChange('companyName', e.target.value)
+                  }}
+                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                  placeholder="Enter company name"
+                />
+                {errors.companyName && (
+                  <p className="text-red-500 text-xs mt-1">{String(errors.companyName.message)}</p>
+                )}
+              </>
+            )
+          })()}
         </div>
       </div>
 
@@ -84,13 +113,26 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
             <User className="w-4 h-4 inline mr-1" />
             Contact Name
           </label>
-          <input
-            type="text"
-            value={data.contactName}
-            onChange={(e) => handleFieldChange('contactName', e.target.value)}
-            className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-            placeholder="Enter contact name"
-          />
+          {(() => {
+            const field = register('contactName')
+            return (
+              <>
+                <input
+                  type="text"
+                  value={data.contactName}
+                  onChange={(e) => {
+                    field.onChange(e)
+                    handleFieldChange('contactName', e.target.value)
+                  }}
+                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                  placeholder="Enter contact name"
+                />
+                {errors.contactName && (
+                  <p className="text-red-500 text-xs mt-1">{String(errors.contactName.message)}</p>
+                )}
+              </>
+            )
+          })()}
         </div>
 
         <div>
@@ -98,13 +140,26 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
             <Phone className="w-4 h-4 inline mr-1" />
             Site Phone
           </label>
-          <input
-            type="tel"
-            value={data.sitePhone}
-            onChange={(e) => handleFieldChange('sitePhone', e.target.value)}
-            className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-            placeholder="Enter site phone"
-          />
+          {(() => {
+            const field = register('sitePhone')
+            return (
+              <>
+                <input
+                  type="tel"
+                  value={data.sitePhone}
+                  onChange={(e) => {
+                    field.onChange(e)
+                    handleFieldChange('sitePhone', e.target.value)
+                  }}
+                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                  placeholder="Enter site phone"
+                />
+                {errors.sitePhone && (
+                  <p className="text-red-500 text-xs mt-1">{String(errors.sitePhone.message)}</p>
+                )}
+              </>
+            )
+          })()}
         </div>
       </div>
 
@@ -113,13 +168,26 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
           <MapPin className="w-4 h-4 inline mr-1" />
           Site Address
         </label>
-        <input
-          type="text"
-          value={data.siteAddress}
-          onChange={(e) => handleFieldChange('siteAddress', e.target.value)}
-          className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-          placeholder="Enter site address"
-        />
+        {(() => {
+          const field = register('siteAddress')
+          return (
+            <>
+              <input
+                type="text"
+                value={data.siteAddress}
+                onChange={(e) => {
+                  field.onChange(e)
+                  handleFieldChange('siteAddress', e.target.value)
+                }}
+                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                placeholder="Enter site address"
+              />
+              {errors.siteAddress && (
+                <p className="text-red-500 text-xs mt-1">{String(errors.siteAddress.message)}</p>
+              )}
+            </>
+          )
+        })()}
       </div>
 
       <div>
@@ -127,15 +195,28 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
           <MapPin className="w-4 h-4 inline mr-1" />
           Shop Location
         </label>
-        <select
-          value={data.shopLocation}
-          onChange={(e) => handleFieldChange('shopLocation', e.target.value)}
-          className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-        >
-          <option value="Shop">Shop</option>
-          <option value="Mukilteo">Mukilteo</option>
-          <option value="Fife">Fife</option>
-        </select>
+        {(() => {
+          const field = register('shopLocation')
+          return (
+            <>
+              <select
+                value={data.shopLocation}
+                onChange={(e) => {
+                  field.onChange(e)
+                  handleFieldChange('shopLocation', e.target.value)
+                }}
+                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+              >
+                <option value="Shop">Shop</option>
+                <option value="Mukilteo">Mukilteo</option>
+                <option value="Fife">Fife</option>
+              </select>
+              {errors.shopLocation && (
+                <p className="text-red-500 text-xs mt-1">{String(errors.shopLocation.message)}</p>
+              )}
+            </>
+          )
+        })()}
       </div>
 
       <div>
@@ -143,13 +224,26 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
           <ClipboardList className="w-4 h-4 inline mr-1" />
           Scope of Work
         </label>
-        <textarea
-          value={data.scopeOfWork}
-          onChange={(e) => handleFieldChange('scopeOfWork', e.target.value)}
-          rows={3}
-          className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent resize-none text-white"
-          placeholder="Describe scope of work"
-        />
+        {(() => {
+          const field = register('scopeOfWork')
+          return (
+            <>
+              <textarea
+                value={data.scopeOfWork}
+                onChange={(e) => {
+                  field.onChange(e)
+                  handleFieldChange('scopeOfWork', e.target.value)
+                }}
+                rows={3}
+                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent resize-none text-white"
+                placeholder="Describe scope of work"
+              />
+              {errors.scopeOfWork && (
+                <p className="text-red-500 text-xs mt-1">{String(errors.scopeOfWork.message)}</p>
+              )}
+            </>
+          )
+        })()}
       </div>
     </div>
   )

--- a/src/components/QuoteSaveManager.tsx
+++ b/src/components/QuoteSaveManager.tsx
@@ -17,6 +17,7 @@ interface QuoteSaveManagerProps {
   ) => void
   isOpen: boolean
   onClose: () => void
+  onValidate?: () => Promise<boolean>
 }
 
 const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
@@ -25,7 +26,8 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
   equipmentRequirements,
   onLoadQuote,
   isOpen,
-  onClose
+  onClose,
+  onValidate
 }) => {
   const [quoteNumber, setQuoteNumber] = useState('')
   const [quotes, setQuotes] = useState<QuoteListItem[]>([])
@@ -87,6 +89,13 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
   }
 
   const handleSaveQuote = async (overwriteId?: string) => {
+    if (onValidate) {
+      const valid = await onValidate()
+      if (!valid) {
+        setMessage({ type: 'error', text: 'Please fix validation errors before saving' })
+        return
+      }
+    }
     if (!quoteNumber.trim()) {
       setMessage({ type: 'error', text: 'Quote number is required' })
       return

--- a/src/components/__tests__/EquipmentForm.test.tsx
+++ b/src/components/__tests__/EquipmentForm.test.tsx
@@ -25,6 +25,8 @@ test('EquipmentForm renders Equipment Quote heading', () => {
       onFieldChange={() => {}}
       onRequirementsChange={() => {}}
       onSelectContact={() => ({}) as HubSpotContact}
+      register={() => ({ onChange: () => {}, onBlur: () => {}, ref: () => {} }) as any}
+      errors={{}}
     />
   );
 

--- a/src/components/__tests__/LogisticsForm.test.tsx
+++ b/src/components/__tests__/LogisticsForm.test.tsx
@@ -31,6 +31,8 @@ test('LogisticsForm renders Logistics Quote heading', () => {
       removePiece={() => {}}
       togglePieceSelection={() => {}}
       deleteSelectedPieces={() => {}}
+      register={() => ({ onChange: () => {}, onBlur: () => {}, ref: () => {} }) as any}
+      errors={{}}
     />
   );
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,44 @@
+import * as yup from 'yup'
+
+export const pieceSchema = yup.object({
+  description: yup.string().required('Description is required'),
+  quantity: yup
+    .number()
+    .typeError('Quantity must be a number')
+    .required('Quantity is required')
+    .min(1, 'Quantity must be at least 1'),
+  length: yup.string().required('Length is required'),
+  width: yup.string().required('Width is required'),
+  height: yup.string().required('Height is required'),
+  weight: yup.string().required('Weight is required')
+})
+
+export const equipmentSchema = yup.object({
+  projectName: yup.string().required('Project name is required'),
+  companyName: yup.string().required('Company name is required'),
+  contactName: yup.string().required('Contact name is required'),
+  siteAddress: yup.string().required('Site address is required'),
+  sitePhone: yup.string().required('Site phone is required'),
+  shopLocation: yup.string().required('Shop location is required'),
+  scopeOfWork: yup.string().required('Scope of work is required')
+})
+
+export const logisticsSchema = yup.object({
+  pieces: yup.array().of(pieceSchema).min(1, 'At least one piece is required'),
+  pickupAddress: yup.string().required('Pickup address is required'),
+  pickupCity: yup.string().required('Pickup city is required'),
+  pickupState: yup.string().required('Pickup state is required'),
+  pickupZip: yup.string().required('Pickup zip is required'),
+  deliveryAddress: yup.string().required('Delivery address is required'),
+  deliveryCity: yup.string().required('Delivery city is required'),
+  deliveryState: yup.string().required('Delivery state is required'),
+  deliveryZip: yup.string().required('Delivery zip is required'),
+  shipmentType: yup.string().required('Shipment type is required'),
+  truckType: yup.string().required('Truck type is required'),
+  storageType: yup.string(),
+  storageSqFt: yup.string().when('storageType', {
+    is: (val: string) => val && val !== '',
+    then: schema => schema.required('Storage square footage is required'),
+    otherwise: schema => schema
+  })
+})

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { equipmentSchema, pieceSchema, logisticsSchema } from '../src/lib/validation'
+
+test('equipmentSchema rejects missing project name', async () => {
+  await assert.rejects(
+    equipmentSchema.validate({
+      projectName: '',
+      companyName: '',
+      contactName: '',
+      siteAddress: '',
+      sitePhone: '',
+      shopLocation: '',
+      scopeOfWork: ''
+    }, { abortEarly: false })
+  )
+})
+
+test('pieceSchema rejects quantity below 1', async () => {
+  await assert.rejects(
+    pieceSchema.validate({
+      description: 'test',
+      quantity: 0,
+      length: '1',
+      width: '1',
+      height: '1',
+      weight: '1'
+    })
+  )
+})
+
+test('logisticsSchema rejects when missing pickup address', async () => {
+  await assert.rejects(
+    logisticsSchema.validate({
+      pieces: [{ description: 'a', quantity: 1, length: '1', width: '1', height: '1', weight: '1' }],
+      pickupAddress: '',
+      pickupCity: 'c',
+      pickupState: 's',
+      pickupZip: 'z',
+      deliveryAddress: 'd',
+      deliveryCity: 'dc',
+      deliveryState: 'ds',
+      deliveryZip: 'dz',
+      shipmentType: 'LTL',
+      truckType: 'Flatbed',
+      storageType: '',
+      storageSqFt: ''
+    })
+  )
+})


### PR DESCRIPTION
## Summary
- integrate react-hook-form with Yup schemas for equipment, logistics, and pieces
- surface field-level validation errors and block saving until valid
- add tests ensuring schemas reject invalid data

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0464f49508321a9b005619c3037ae