### PR TITLE
Remove leading blank line in scope of work template

### DIFF
--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -99,9 +99,7 @@ export const generateScopeTemplate = (
           .join('\n')}\n`
       : ''
 
-  return `
-
-Mobilize crew and Omega Morgan equipment to site: ${siteAddress}
+  return `Mobilize crew and Omega Morgan equipment to site: ${siteAddress}
 
 ${contactName}
 ${phone}


### PR DESCRIPTION
## Summary
- remove leading newline from scope of work template output to avoid blank line at top

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find module 'acorn')*

------
https://chatgpt.com/codex/tasks/task_e_68c059e110008321a418a9c7a0e49368