### PR TITLE
Populate site contact fields from HubSpot

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { EquipmentData, LogisticsData } from './types'
 import { useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { equipmentSchema, logisticsSchema } from './lib/validation'
+import { HubSpotContact } from './services/hubspotService'
 
 const App: React.FC = () => {
   const {
@@ -39,7 +40,7 @@ const App: React.FC = () => {
     initialEquipmentData,
     handleEquipmentChange,
     handleEquipmentRequirementsChange,
-    handleSelectHubSpotContact
+    handleSelectHubSpotContact: baseHandleSelectHubSpotContact
   } = useEquipmentForm()
 
   const {
@@ -103,6 +104,16 @@ const App: React.FC = () => {
     }
   }, [equipmentData.siteAddress])
 
+  const handleSelectHubSpotContact = (contact: HubSpotContact) => {
+    baseHandleSelectHubSpotContact(contact)
+    setLogisticsData(prev => ({
+      ...prev,
+      pickupAddress: contact.contactAddress1 || contact.companyAddress1 || prev.pickupAddress,
+      pickupCity: contact.contactCity || contact.companyCity || prev.pickupCity,
+      pickupState: contact.contactState || contact.companyState || prev.pickupState,
+      pickupZip: contact.contactZip || contact.companyZip || prev.pickupZip
+    }))
+  }
 
   const handleAIExtraction = (
     extractedEquipmentData: Partial<EquipmentData>,

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -10,11 +10,11 @@ export const generateEmailTemplate = (
   _equipmentRequirements: any
 ) => {
   const projectName = equipmentData.projectName || '[project name]'
-  const contactName = equipmentData.contactName || '[contact name]'
+  const contactName = equipmentData.contactName || '[site contact]'
   const siteAddress = equipmentData.siteAddress || '[site address]'
   const scopeOfWork = equipmentData.scopeOfWork || '[Scope of Work]'
 
-  return `Subject: Quote Request - ${projectName}\n\nDear ${contactName},\n\nI hope this email finds you well. Thank you for considering Omega Morgan for the scope of work attached and summarized below.\n\nPROJECT DETAILS:\n• Project Name: ${projectName}\n• Contact Name: ${contactName}\n• Project Location: ${siteAddress}\n\nSCOPE OF WORK:\n\n${scopeOfWork}\n\nThank you for your time and consideration. I look forward to hearing from you soon.\n\nBest regards,`
+  return `Subject: Quote Request - ${projectName}\n\nDear ${contactName},\n\nI hope this email finds you well. Thank you for considering Omega Morgan for the scope of work attached and summarized below.\n\nPROJECT DETAILS:\n• Project Name: ${projectName}\n• Site Contact: ${contactName}\n• Project Location: ${siteAddress}\n\nSCOPE OF WORK:\n\n${scopeOfWork}\n\nThank you for your time and consideration. I look forward to hearing from you soon.\n\nBest regards,`
 }
 
 export const generateScopeTemplate = (
@@ -24,7 +24,7 @@ export const generateScopeTemplate = (
 ) => {
   const siteAddress = equipmentData.siteAddress || '[Site Address]'
   const contactName = equipmentData.contactName || '[Site Contact]'
-  const phone = equipmentData.sitePhone || '[Site Contact Phone Number]'
+  const phone = equipmentData.sitePhone || '[Site Phone]'
   const shopLocation = equipmentData.shopLocation || '[Shop]'
   const scopeOfWork = equipmentData.scopeOfWork || ''
 
@@ -68,22 +68,13 @@ export const generateScopeTemplate = (
     }`
   })()
 
-  const shipmentLine = logisticsData.shipmentType
-    ? `Shipment Type: ${logisticsData.shipmentType}\n`
-    : ''
-  const truckLine = logisticsData.truckType
-    ? `Truck Type Requested: ${logisticsData.truckType}\n`
-    : ''
   const storageLine = logisticsData.storageType
     ? `Storage: ${
         logisticsData.storageType === 'inside' ? 'Inside Storage' : 'Outside Storage'
       } - ${logisticsData.storageSqFt || '[Sq Ft]'} sq ft\n`
     : ''
 
-  const logisticsSection =
-    shipmentLine || truckLine || storageLine
-      ? `\n${shipmentLine}${truckLine}${storageLine}`
-      : '\n'
+  const logisticsSection = storageLine ? `\n${storageLine}` : '\n'
 
   const itemsSection =
     logisticsData.pieces && logisticsData.pieces.length > 0

--- a/src/components/ProjectDetails.tsx
+++ b/src/components/ProjectDetails.tsx
@@ -111,7 +111,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
         <div>
           <label className="block text-sm font-medium text-white mb-2">
             <User className="w-4 h-4 inline mr-1" />
-            Contact Name
+            Site Contact
           </label>
           {(() => {
             const field = register('contactName')
@@ -125,7 +125,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
                     handleFieldChange('contactName', e.target.value)
                   }}
                   className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                  placeholder="Enter contact name"
+                  placeholder="Enter site contact"
                 />
                 {errors.contactName && (
                   <p className="text-red-500 text-xs mt-1">{String(errors.contactName.message)}</p>

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -16,7 +16,7 @@ export const pieceSchema = yup.object({
 export const equipmentSchema = yup.object({
   projectName: yup.string().required('Project name is required'),
   companyName: yup.string().required('Company name is required'),
-  contactName: yup.string().required('Contact name is required'),
+  contactName: yup.string().required('Site contact is required'),
   siteAddress: yup.string().required('Site address is required'),
   sitePhone: yup.string().required('Site phone is required'),
   shopLocation: yup.string().required('Shop location is required'),


### PR DESCRIPTION
## Summary
- Populate pickup address, city, state, and zip when selecting a HubSpot contact
- Rename contact fields to "Site Contact"/"Site Phone" across forms and templates
- Remove truck and shipment types from scope of work template

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module 'acorn')*

------
https://chatgpt.com/codex/tasks/task_e_68c0938772688321bd9443466ab12872