### PR TITLE
Add HubSpot contact update via Supabase

### DIFF
--- a/src/services/hubspotService.ts
+++ b/src/services/hubspotService.ts
@@ -43,6 +43,26 @@ export class HubSpotService {
     const data = await response.json()
     return data.results || []
   }
+
+  static async updateContact(id: string, payload: Partial<HubSpotContact>): Promise<void> {
+    if (!this.SUPABASE_URL || !this.SUPABASE_ANON_KEY) {
+      throw new Error('Supabase configuration missing')
+    }
+
+    const response = await fetch(`${this.SUPABASE_URL}/functions/v1/hubspot-update`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.SUPABASE_ANON_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ id, properties: payload }),
+    })
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ error: 'Network error' }))
+      throw new Error(err.error || 'Failed to update contact')
+    }
+  }
 }
 
 

--- a/supabase/functions/hubspot-update/index.ts
+++ b/supabase/functions/hubspot-update/index.ts
@@ -1,0 +1,73 @@
+import { createClient } from 'npm:@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+interface UpdateRequestBody {
+  id: string
+  properties: Record<string, unknown>
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders })
+  }
+
+  try {
+    createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    )
+
+    const token = Deno.env.get('HUBSPOT_PRIVATE_APP_TOKEN')
+    if (!token) {
+      return new Response(JSON.stringify({ error: 'Missing HUBSPOT_PRIVATE_APP_TOKEN secret' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const body: UpdateRequestBody = await req.json().catch(() => ({ id: '', properties: {} }))
+    const contactId = body.id?.trim()
+    const props = body.properties || {}
+
+    if (!contactId || Object.keys(props).length === 0) {
+      return new Response(JSON.stringify({ error: 'Contact id and properties are required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const hsRes = await fetch(`https://api.hubapi.com/crm/v3/objects/contacts/${contactId}`, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ properties: props }),
+    })
+
+    if (!hsRes.ok) {
+      const errText = await hsRes.text().catch(() => 'HubSpot error')
+      return new Response(JSON.stringify({ error: `HubSpot update failed: ${errText}` }), {
+        status: 502,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const data = await hsRes.json().catch(() => ({}))
+    return new Response(JSON.stringify({ result: data }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err instanceof Error ? err.message : 'Unknown error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+})
+


### PR DESCRIPTION
## Summary
- add `hubspot-update` edge function to patch contact fields
- extend HubSpot service with `updateContact`
- update project details form to save changes back to HubSpot and show status

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Unexpected any in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c09cce3e088321bd9ab7713becd760