### PR TITLE
feat: add manual HubSpot save

### DIFF
--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,50 +1,54 @@
-import test from 'node:test'
-import assert from 'node:assert'
+import { describe, it, expect } from 'vitest'
 import { equipmentSchema, pieceSchema, logisticsSchema } from '../src/lib/validation'
 
-test('equipmentSchema rejects missing project name', async () => {
-  await assert.rejects(
-    equipmentSchema.validate({
-      projectName: '',
-      companyName: '',
-      contactName: '',
-      siteAddress: '',
-      sitePhone: '',
-      shopLocation: '',
-      scopeOfWork: ''
-    }, { abortEarly: false })
-  )
-})
+describe('validation schemas', () => {
+  it('equipmentSchema rejects missing project name', async () => {
+    await expect(
+      equipmentSchema.validate(
+        {
+          projectName: '',
+          companyName: '',
+          contactName: '',
+          siteAddress: '',
+          sitePhone: '',
+          shopLocation: '',
+          scopeOfWork: ''
+        },
+        { abortEarly: false }
+      )
+    ).rejects.toBeDefined()
+  })
 
-test('pieceSchema rejects quantity below 1', async () => {
-  await assert.rejects(
-    pieceSchema.validate({
-      description: 'test',
-      quantity: 0,
-      length: '1',
-      width: '1',
-      height: '1',
-      weight: '1'
-    })
-  )
-})
+  it('pieceSchema rejects quantity below 1', async () => {
+    await expect(
+      pieceSchema.validate({
+        description: 'test',
+        quantity: 0,
+        length: '1',
+        width: '1',
+        height: '1',
+        weight: '1'
+      })
+    ).rejects.toBeDefined()
+  })
 
-test('logisticsSchema rejects when missing pickup address', async () => {
-  await assert.rejects(
-    logisticsSchema.validate({
-      pieces: [{ description: 'a', quantity: 1, length: '1', width: '1', height: '1', weight: '1' }],
-      pickupAddress: '',
-      pickupCity: 'c',
-      pickupState: 's',
-      pickupZip: 'z',
-      deliveryAddress: 'd',
-      deliveryCity: 'dc',
-      deliveryState: 'ds',
-      deliveryZip: 'dz',
-      shipmentType: 'LTL',
-      truckType: 'Flatbed',
-      storageType: '',
-      storageSqFt: ''
-    })
-  )
+  it('logisticsSchema rejects when missing pickup address', async () => {
+    await expect(
+      logisticsSchema.validate({
+        pieces: [{ description: 'a', quantity: 1, length: '1', width: '1', height: '1', weight: '1' }],
+        pickupAddress: '',
+        pickupCity: 'c',
+        pickupState: 's',
+        pickupZip: 'z',
+        deliveryAddress: 'd',
+        deliveryCity: 'dc',
+        deliveryState: 'ds',
+        deliveryZip: 'dz',
+        shipmentType: 'LTL',
+        truckType: 'Flatbed',
+        storageType: '',
+        storageSqFt: ''
+      })
+    ).rejects.toBeDefined()
+  })
 })


### PR DESCRIPTION
## Summary
- add Save to HubSpot button in project details to push staged contact edits
- track pending contact field changes and update on save
- convert validation tests to Vitest

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68c18a7dbab083219ce0c07b543ce66d