### PR TITLE
feat: add copy button for project name field

### DIFF
--- a/src/components/ProjectDetails.tsx
+++ b/src/components/ProjectDetails.tsx
@@ -1,5 +1,16 @@
 import React, { useState } from 'react'
-import { FileText, Building, User, Phone, MapPin, ClipboardList, X, Save } from 'lucide-react'
+import {
+  FileText,
+  Building,
+  User,
+  Phone,
+  MapPin,
+  ClipboardList,
+  X,
+  Save,
+  Copy,
+  CheckCircle
+} from 'lucide-react'
 import HubSpotContactSearch from './HubSpotContactSearch'
 import { HubSpotContact, HubSpotService } from '../services/hubspotService'
 import { UseFormRegister, FieldErrors } from 'react-hook-form'
@@ -28,6 +39,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
   const [pendingUpdates, setPendingUpdates] = useState<Record<string, unknown>>({})
   const [updateMessage, setUpdateMessage] = useState<string | null>(null)
   const [updateError, setUpdateError] = useState<string | null>(null)
+  const [projectNameCopied, setProjectNameCopied] = useState(false)
   const handleFieldChange = (field: keyof ProjectDetailsData, value: string) => {
     onChange(field, value)
     if (selectedContactId) {
@@ -67,6 +79,16 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
     setSelectedContactId(contact.id)
     setPendingUpdates({})
     onSelectContact(contact)
+  }
+
+  const handleCopyProjectName = async () => {
+    try {
+      await navigator.clipboard.writeText(data.projectName)
+      setProjectNameCopied(true)
+      setTimeout(() => setProjectNameCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy project name', err)
+    }
   }
 
   const clearSection = () => {
@@ -117,16 +139,31 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
             const field = register('projectName')
             return (
               <>
-                <input
-                  type="text"
-                  value={data.projectName}
-                  onChange={(e) => {
-                    field.onChange(e)
-                    handleFieldChange('projectName', e.target.value)
-                  }}
-                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                  placeholder="Enter project name"
-                />
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={data.projectName}
+                    onChange={(e) => {
+                      field.onChange(e)
+                      handleFieldChange('projectName', e.target.value)
+                    }}
+                    className="flex-1 px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                    placeholder="Enter project name"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleCopyProjectName}
+                    disabled={!data.projectName}
+                    aria-label="Copy project name"
+                    className="p-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors border border-accent disabled:opacity-50"
+                  >
+                    {projectNameCopied ? (
+                      <CheckCircle className="w-4 h-4" />
+                    ) : (
+                      <Copy className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
                 {errors.projectName && (
                   <p className="text-red-500 text-xs mt-1">{String(errors.projectName.message)}</p>
                 )}

--- a/tests/ProjectDetails.test.tsx
+++ b/tests/ProjectDetails.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import React from 'react'
+import ProjectDetails, { ProjectDetailsData } from '../src/components/ProjectDetails'
+
+vi.mock('../src/components/HubSpotContactSearch', () => ({
+  default: () => <div />
+}))
+
+describe('ProjectDetails copy button', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) }
+    })
+  })
+
+  it('copies project name to clipboard', async () => {
+    const data: ProjectDetailsData = {
+      projectName: 'My Project',
+      companyName: '',
+      contactName: '',
+      siteAddress: '',
+      sitePhone: '',
+      shopLocation: '',
+      scopeOfWork: '',
+      email: ''
+    }
+
+    render(
+      <ProjectDetails
+        data={data}
+        onChange={() => {}}
+        onSelectContact={() => {}}
+        register={() => ({ onChange: () => {} }) as any}
+        errors={{}}
+      />
+    )
+
+    const button = screen.getByLabelText(/copy project name/i)
+    fireEvent.click(button)
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('My Project')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add clipboard copy button next to project name input
- test project name copy behavior

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68c18c98755c83218bec1df5455ae6a6