### PR TITLE
feat: add logistics email template

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,14 +9,16 @@ import {
   Copy,
   CheckCircle,
   Mail,
-  Save
+  Save,
+  Truck
 } from 'lucide-react'
 import { useSessionId } from './hooks/useSessionId'
 import { useApiKey } from './hooks/useApiKey'
 import AIExtractorModal from './components/AIExtractorModal'
 import {
   generateEmailTemplate,
-  generateScopeTemplate
+  generateScopeTemplate,
+  generateLogisticsEmail
 } from './components/PreviewTemplates'
 import QuoteSaveManager from './components/QuoteSaveManager'
 import ApiKeySetup from './components/ApiKeySetup'
@@ -197,7 +199,9 @@ const App: React.FC = () => {
     setSelectedPieces([])
   }
 
-  const [copiedTemplate, setCopiedTemplate] = useState<string | null>(null)
+  const [copiedTemplate, setCopiedTemplate] = useState<
+    'email' | 'scope' | 'logistics' | null
+  >(null)
 
   const emailTemplate = generateEmailTemplate(
     equipmentData,
@@ -211,9 +215,13 @@ const App: React.FC = () => {
     equipmentData.equipmentRequirements
   )
 
+  const { subject: logisticsSubject, body: logisticsBody } =
+    generateLogisticsEmail(equipmentData, logisticsData)
+  const logisticsTemplate = `Subject: ${logisticsSubject}\n\n${logisticsBody}`
+
   const copyToClipboard = async (
     text: string,
-    templateType: 'email' | 'scope'
+    templateType: 'email' | 'scope' | 'logistics'
   ) => {
     try {
       await navigator.clipboard.writeText(text)
@@ -369,9 +377,44 @@ const App: React.FC = () => {
             </div>
           </div>
 
-          <p className="text-sm text-white">
-            
-          </p>
+          <div className="bg-gray-900 rounded-lg border-2 border-accent p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center">
+                <Truck className="w-6 h-6 text-white mr-2" />
+                <h2 className="text-2xl font-bold text-white">Logistics Email Template</h2>
+              </div>
+              <div className="flex gap-2">
+                <a
+                  href={`mailto:Logistics@omegamorgan.com,MachineryLogistics@omegamorgan.com?subject=${encodeURIComponent(logisticsSubject)}&body=${encodeURIComponent(logisticsBody)}`}
+                  className="flex items-center px-4 py-2 bg-accent text-black rounded-lg hover:bg-green-400 transition-colors"
+                >
+                  <Mail className="w-4 h-4 mr-2" />
+                  Email
+                </a>
+                <button
+                  onClick={() => copyToClipboard(logisticsTemplate, 'logistics')}
+                  className="flex items-center px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors border border-accent"
+                >
+                  {copiedTemplate === 'logistics' ? (
+                    <>
+                      <CheckCircle className="w-4 h-4 mr-2" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="w-4 h-4 mr-2" />
+                      Copy
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+            <div className="bg-black rounded-lg p-4 border border-accent">
+              <pre className="whitespace-pre-wrap text-sm text-white font-mono leading-relaxed">
+                {logisticsTemplate}
+              </pre>
+            </div>
+          </div>
         </div>
 
         {/* Clarifications */}

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -100,7 +100,7 @@ Omega Morgan to supply ${equipmentSummary || 'necessary crew and equipment'}.
 ${logisticsSection}${scopeOfWork ? `${scopeOfWork}\n\n` : ''}${itemsSection}When job is complete clean up debris and return to ${shopLocation}.`
 }
 
-export const generateLogisticsTemplate = (
+export const generateLogisticsEmail = (
   equipmentData: any,
   logisticsData: any
 ) => {
@@ -141,34 +141,19 @@ export const generateLogisticsTemplate = (
   const contactName = equipmentData.contactName || ''
   const companyName = equipmentData.companyName || ''
 
-  return `To: Logistics@omegamorgan.com; MachineryLogistics@omegamorgan.com
+  const subject = `Quote for Truck Request for ${shipmentType} - ${pickupZip} - ${deliveryZip}`
 
-Subject: Quote for Truck Request for ${shipmentType} - ${pickupZip} - ${deliveryZip}
+  const body = `Hello Team,\n\nI'm reaching out to request a logistics quote for an upcoming project. Please see the load and transport details below:\n\nNumber of Pieces: ${totalPieces}\n\n${itemsSection}\n\nTotal Load Weight: ${totalWeight}\n\nPick-Up Location: ${pickupLocation}\n\nDelivery/Set Location: ${deliveryLocation}\n\nTruck Type Requested: ${truckType}\n\nShipment Type: ${shipmentType}\n\nPlease let me know if you need any additional information or documents to complete the quote.\n\nLooking forward to your response.\n\nThanks,\n${contactName}${companyName ? `\n${companyName}` : ''}`
 
-Hello Team,
+  return { subject, body }
+}
 
-I'm reaching out to request a logistics quote for an upcoming project. Please see the load and transport details below:
-
-Number of Pieces: ${totalPieces}
-
-${itemsSection}
-
-Total Load Weight: ${totalWeight}
-
-Pick-Up Location: ${pickupLocation}
-
-Delivery/Set Location: ${deliveryLocation}
-
-Truck Type Requested: ${truckType}
-
-Shipment Type: ${shipmentType}
-
-Please let me know if you need any additional information or documents to complete the quote.
-
-Looking forward to your response.
-
-Thanks,
-${contactName}${companyName ? `\n${companyName}` : ''}`
+export const generateLogisticsTemplate = (
+  equipmentData: any,
+  logisticsData: any
+) => {
+  const { subject, body } = generateLogisticsEmail(equipmentData, logisticsData)
+  return `To: Logistics@omegamorgan.com; MachineryLogistics@omegamorgan.com\n\nSubject: ${subject}\n\n${body}`
 }
 
 interface PreviewTemplatesProps {


### PR DESCRIPTION
## Summary
- add generator for logistics email content
- display logistics email template with copy and email actions

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any & unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68c19b7534e08321891cb269dedda4c8