### PR TITLE
Ensure clean separation before final cleanup instruction

### DIFF
--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -97,7 +97,7 @@ ${contactName}
 ${phone}
 
 Omega Morgan to supply ${equipmentSummary || 'necessary crew and equipment'}.
-${logisticsSection}${scopeOfWork ? `${scopeOfWork}\n\n` : ''}${itemsSection}When job is complete clean up debris and return to ${shopLocation}.`
+${logisticsSection}${scopeOfWork ? `${scopeOfWork}\n\n` : ''}${itemsSection}\nWhen job is complete clean up debris and return to ${shopLocation}.`
 }
 
 export const generateLogisticsEmail = (


### PR DESCRIPTION
## Summary
- add explicit blank line before closing cleanup sentence in scope template

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2de18edd08321b6e005a5ff9d15b0