### PR TITLE
Use first name for customer in email template

### DIFF
--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -11,10 +11,13 @@ export const generateEmailTemplate = (
 ) => {
   const projectName = equipmentData.projectName || '[project name]'
   const contactName = equipmentData.contactName || '[site contact]'
+  const contactFirstName = equipmentData.contactName
+    ? equipmentData.contactName.trim().split(/\s+/)[0]
+    : contactName
   const siteAddress = equipmentData.siteAddress || '[site address]'
   const scopeOfWork = equipmentData.scopeOfWork || '[Scope of Work]'
 
-  return `Quote Request - ${projectName}\n\nDear ${contactName},\n\nI hope this email finds you well. Thank you for considering Omega Morgan for the scope of work attached and summarized below.\n\nPROJECT DETAILS:\n• Project Name: ${projectName}\n• Site Contact: ${contactName}\n• Project Location: ${siteAddress}\n\nSCOPE OF WORK:\n\n${scopeOfWork}\n\nThank you for your time and consideration. I look forward to hearing from you soon.\n\nBest regards,`
+  return `Quote Request - ${projectName}\n\nDear ${contactFirstName},\n\nI hope this email finds you well. Thank you for considering Omega Morgan for the scope of work attached and summarized below.\n\nPROJECT DETAILS:\n• Project Name: ${projectName}\n• Site Contact: ${contactFirstName}\n• Project Location: ${siteAddress}\n\nSCOPE OF WORK:\n\n${scopeOfWork}\n\nThank you for your time and consideration. I look forward to hearing from you soon.\n\nBest regards,`
 }
 
 export const generateScopeTemplate = (


### PR DESCRIPTION
## Summary
- use only customer's first name when generating email template

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, unused vars)*
- `npx eslint src/components/PreviewTemplates.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c2de4a39288321a6c5787cfaca6511