### PR TITLE
Remove Subject prefix from logistics email template

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,7 +217,7 @@ const App: React.FC = () => {
 
   const { subject: logisticsSubject, body: logisticsBody } =
     generateLogisticsEmail(equipmentData, logisticsData)
-  const logisticsTemplate = `Subject: ${logisticsSubject}\n\n${logisticsBody}`
+  const logisticsTemplate = `${logisticsSubject}\n\n${logisticsBody}`
 
   const copyToClipboard = async (
     text: string,

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -153,7 +153,7 @@ export const generateLogisticsTemplate = (
   logisticsData: any
 ) => {
   const { subject, body } = generateLogisticsEmail(equipmentData, logisticsData)
-  return `To: Logistics@omegamorgan.com; MachineryLogistics@omegamorgan.com\n\nSubject: ${subject}\n\n${body}`
+  return `To: Logistics@omegamorgan.com; MachineryLogistics@omegamorgan.com\n\n${subject}\n\n${body}`
 }
 
 interface PreviewTemplatesProps {


### PR DESCRIPTION
## Summary
- remove `Subject:` prefix from logistics email template

## Testing
- `npm test` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c2defdc3bc8321b27f8002d70f83fd