### PR TITLE
feat: auto title case project name

### DIFF
--- a/src/components/ProjectDetails.tsx
+++ b/src/components/ProjectDetails.tsx
@@ -14,6 +14,7 @@ import {
 import HubSpotContactSearch from './HubSpotContactSearch'
 import { HubSpotContact, HubSpotService } from '../services/hubspotService'
 import { UseFormRegister, FieldErrors } from 'react-hook-form'
+import { toTitleCase } from '../lib/titleCase'
 
 export interface ProjectDetailsData {
   projectName: string
@@ -40,7 +41,8 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
   const [updateMessage, setUpdateMessage] = useState<string | null>(null)
   const [updateError, setUpdateError] = useState<string | null>(null)
   const [projectNameCopied, setProjectNameCopied] = useState(false)
-  const handleFieldChange = (field: keyof ProjectDetailsData, value: string) => {
+  const handleFieldChange = (field: keyof ProjectDetailsData, rawValue: string) => {
+    const value = field === 'projectName' ? toTitleCase(rawValue) : rawValue
     onChange(field, value)
     if (selectedContactId) {
       setPendingUpdates(prev => {
@@ -144,8 +146,10 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
                     type="text"
                     value={data.projectName}
                     onChange={(e) => {
+                      const formattedValue = toTitleCase(e.target.value)
+                      e.target.value = formattedValue
                       field.onChange(e)
-                      handleFieldChange('projectName', e.target.value)
+                      handleFieldChange('projectName', formattedValue)
                     }}
                     className="flex-1 px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
                     placeholder="Enter project name"

--- a/src/lib/__tests__/titleCase.test.ts
+++ b/src/lib/__tests__/titleCase.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { toTitleCase } from '../titleCase'
+
+describe('toTitleCase', () => {
+  it('capitalizes the first example phrase correctly', () => {
+    expect(toTitleCase('fort know is amazing')).toBe('Fort Know Is Amazing')
+  })
+
+  it('capitalizes the second example phrase correctly', () => {
+    expect(toTitleCase('port of tacoma is awesome')).toBe('Port of Tacoma Is Awesome')
+  })
+
+  it('capitalizes the third example phrase correctly', () => {
+    expect(toTitleCase('seattle is the best')).toBe('Seattle Is the Best')
+  })
+
+  it('keeps articles and conjunctions lowercase when appropriate', () => {
+    expect(toTitleCase('the rise and fall of ziggy')).toBe('The Rise and Fall of Ziggy')
+  })
+
+  it('capitalizes each part of a hyphenated major word', () => {
+    expect(toTitleCase('state-of-the-art equipment')).toBe('State-Of-The-Art Equipment')
+  })
+
+  it('preserves acronyms', () => {
+    expect(toTitleCase('NASA facility')).toBe('NASA Facility')
+  })
+
+  it('preserves trailing whitespace for in-progress typing', () => {
+    expect(toTitleCase('port of tacoma ')).toBe('Port of Tacoma ')
+  })
+})

--- a/src/lib/titleCase.ts
+++ b/src/lib/titleCase.ts
@@ -1,0 +1,96 @@
+const LOWERCASE_WORDS = new Set([
+  'a',
+  'an',
+  'the',
+  'and',
+  'but',
+  'or',
+  'nor',
+  'for',
+  'yet',
+  'in',
+  'on',
+  'at',
+  'by',
+  'of',
+  'to',
+  'up'
+])
+
+const processWord = (word: string, index: number, totalWords: number): string => {
+  if (!word) {
+    return word
+  }
+
+  const leading = word.match(/^[^A-Za-z0-9]+/u)?.[0] ?? ''
+  const trailing = word.match(/[^A-Za-z0-9]+$/u)?.[0] ?? ''
+  const core = word.slice(leading.length, word.length - trailing.length)
+
+  if (!core) {
+    return word
+  }
+
+  const shouldAlwaysCapitalize = index === 0 || index === totalWords - 1
+  const parts = core.split('-')
+
+  const transformed = parts
+    .map((part, partIndex) => {
+      if (!part) {
+        return part
+      }
+
+      const lowerPart = part.toLowerCase()
+      const shouldCapitalize =
+        shouldAlwaysCapitalize || !LOWERCASE_WORDS.has(lowerPart) || partIndex > 0
+
+      if (!shouldCapitalize) {
+        return lowerPart
+      }
+
+      const isAllCaps = part === part.toUpperCase() && /[A-Z]/.test(part)
+
+      if (isAllCaps) {
+        return part
+      }
+
+      const firstChar = lowerPart[0]?.toUpperCase() ?? ''
+      const originalRest = part.slice(1)
+      const lowerRest = lowerPart.slice(1)
+      const hasUppercaseInRest = /[A-Z]/.test(originalRest)
+      const hasLowercaseInRest = /[a-z]/.test(originalRest)
+
+      if (hasUppercaseInRest && hasLowercaseInRest) {
+        return `${firstChar}${originalRest}`
+      }
+
+      return `${firstChar}${lowerRest}`
+    })
+    .join('-')
+
+  return `${leading}${transformed}${trailing}`
+}
+
+export const toTitleCase = (input: string): string => {
+  if (!input) {
+    return input
+  }
+
+  const leadingWhitespace = input.match(/^\s+/)?.[0] ?? ''
+  const trailingWhitespace = input.match(/\s+$/)?.[0] ?? ''
+  const trimmed = input.trim()
+
+  if (!trimmed) {
+    return input
+  }
+
+  const words = trimmed.split(/\s+/)
+  const totalWords = words.length
+
+  const transformedWords = words.map((word, index) =>
+    processWord(word, index, totalWords)
+  )
+
+  return `${leadingWhitespace}${transformedWords.join(' ')}${trailingWhitespace}`
+}
+
+export default toTitleCase


### PR DESCRIPTION
## Summary
- add a reusable title casing helper that follows the project name capitalization rules
- format the project name input with title casing as the user types
- cover the capitalization logic with unit tests, including the provided examples

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c898a52a5483218dc23e7779630802