### PR TITLE
Add site address copy button for pickup location

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -311,7 +311,9 @@ const App: React.FC = () => {
             togglePieceSelection={togglePieceSelection}
             deleteSelectedPieces={deleteSelectedPieces}
             register={logisticsForm.register}
+            setValue={logisticsForm.setValue}
             errors={logisticsForm.formState.errors}
+            siteAddress={equipmentData.siteAddress || ''}
           />
         </div>
 

--- a/src/components/LogisticsForm.tsx
+++ b/src/components/LogisticsForm.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import { Truck, Package, Plus, Minus, Trash2 } from 'lucide-react'
-import { UseFormRegister, FieldErrors } from 'react-hook-form'
+import React, { useState } from 'react'
+import { Truck, Package, Plus, Minus, Trash2, Copy, CheckCircle } from 'lucide-react'
+import { UseFormRegister, FieldErrors, UseFormSetValue } from 'react-hook-form'
 
 interface Piece {
   description: string;
@@ -41,7 +41,9 @@ interface LogisticsFormProps {
   togglePieceSelection: (index: number) => void;
   deleteSelectedPieces: () => void;
   register: UseFormRegister<LogisticsData>;
+  setValue: UseFormSetValue<LogisticsData>;
   errors: FieldErrors<LogisticsData>;
+  siteAddress?: string;
 }
 
 const LogisticsForm: React.FC<LogisticsFormProps> = ({
@@ -54,8 +56,20 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
   togglePieceSelection,
   deleteSelectedPieces,
   register,
-  errors
+  setValue,
+  errors,
+  siteAddress = ''
 }) => {
+  const [copiedSiteAddress, setCopiedSiteAddress] = useState(false)
+
+  const handleCopySiteAddress = () => {
+    if (!siteAddress) return
+    onFieldChange('pickupAddress', siteAddress)
+    setValue('pickupAddress', siteAddress, { shouldValidate: true, shouldDirty: true })
+    setCopiedSiteAddress(true)
+    setTimeout(() => setCopiedSiteAddress(false), 2000)
+  }
+
   return (
     <div className="bg-gray-900 rounded-lg border-2 border-accent p-6">
       <div className="flex items-center mb-6">
@@ -219,16 +233,31 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
               const field = register('pickupAddress')
               return (
                 <>
-                  <input
-                    type="text"
-                    value={data.pickupAddress}
-                    onChange={(e) => {
-                      field.onChange(e)
-                      onFieldChange('pickupAddress', e.target.value)
-                    }}
-                    className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                    placeholder="Pickup address"
-                  />
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      value={data.pickupAddress}
+                      onChange={(e) => {
+                        field.onChange(e)
+                        onFieldChange('pickupAddress', e.target.value)
+                      }}
+                      className="flex-1 px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                      placeholder="Pickup address"
+                    />
+                    <button
+                      type="button"
+                      onClick={handleCopySiteAddress}
+                      disabled={!siteAddress}
+                      aria-label="Copy site address to pickup location"
+                      className="p-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors border border-accent disabled:opacity-50"
+                    >
+                      {copiedSiteAddress ? (
+                        <CheckCircle className="w-4 h-4" />
+                      ) : (
+                        <Copy className="w-4 h-4" />
+                      )}
+                    </button>
+                  </div>
                   {errors.pickupAddress && (
                     <p className="text-red-500 text-xs mt-1">{String(errors.pickupAddress.message)}</p>
                   )}

--- a/src/components/__tests__/LogisticsForm.test.tsx
+++ b/src/components/__tests__/LogisticsForm.test.tsx
@@ -32,7 +32,9 @@ test('LogisticsForm renders Logistics Quote heading', () => {
       togglePieceSelection={() => {}}
       deleteSelectedPieces={() => {}}
       register={() => ({ onChange: () => {}, onBlur: () => {}, ref: () => {} }) as any}
+      setValue={(() => {}) as any}
       errors={{}}
+      siteAddress=""
     />
   );
 


### PR DESCRIPTION
## Summary
- add a copy button in the logistics form to pull the site address into the pickup address field
- sync the logistics form with react-hook-form when copying and reuse the copy/check styling for feedback
- pass the equipment site address to the logistics form and update the associated unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9b9c1fc9c8321b2fe9e35150e1ba6