### PR TITLE
Add copy-to-pickup button for site address

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { EquipmentData, LogisticsData } from './types'
 import { useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { equipmentSchema, logisticsSchema } from './lib/validation'
+import { parseAddressParts } from './lib/address'
 import { HubSpotContact } from './services/hubspotService'
 
 const App: React.FC = () => {
@@ -105,6 +106,25 @@ const App: React.FC = () => {
       }))
     }
   }, [equipmentData.siteAddress])
+
+  const copySiteAddressToPickup = () => {
+    const siteAddress = equipmentData.siteAddress?.trim()
+    if (!siteAddress) {
+      return false
+    }
+
+    const { street, city, state, zip } = parseAddressParts(siteAddress)
+
+    setLogisticsData(prev => ({
+      ...prev,
+      pickupAddress: street || siteAddress,
+      pickupCity: city,
+      pickupState: state,
+      pickupZip: zip
+    }))
+
+    return true
+  }
 
   const handleSelectHubSpotContact = (contact: HubSpotContact) => {
     baseHandleSelectHubSpotContact(contact)
@@ -296,6 +316,7 @@ const App: React.FC = () => {
             onFieldChange={handleEquipmentChange}
             onRequirementsChange={handleEquipmentRequirementsChange}
             onSelectContact={handleSelectHubSpotContact}
+            onCopySiteAddress={copySiteAddressToPickup}
             register={equipmentForm.register}
             errors={equipmentForm.formState.errors}
           />

--- a/src/components/EquipmentForm.tsx
+++ b/src/components/EquipmentForm.tsx
@@ -11,6 +11,7 @@ interface EquipmentFormProps {
   onFieldChange: (field: string, value: string) => void;
   onRequirementsChange: (data: EquipmentRequirements) => void;
   onSelectContact: (contact: HubSpotContact) => void;
+  onCopySiteAddress: () => boolean;
   register: UseFormRegister<EquipmentData>;
   errors: FieldErrors<EquipmentData>;
 }
@@ -20,6 +21,7 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({
   onFieldChange,
   onRequirementsChange,
   onSelectContact,
+  onCopySiteAddress,
   register,
   errors
 }) => {
@@ -33,6 +35,7 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({
         data={data}
         onChange={onFieldChange}
         onSelectContact={onSelectContact}
+        onCopySiteAddress={onCopySiteAddress}
         register={register}
         errors={errors}
       />

--- a/src/components/ProjectDetails.tsx
+++ b/src/components/ProjectDetails.tsx
@@ -31,16 +31,25 @@ interface ProjectDetailsProps {
   data: ProjectDetailsData
   onChange: (field: keyof ProjectDetailsData, value: string) => void
   onSelectContact: (contact: HubSpotContact) => void
+  onCopySiteAddress: () => boolean
   register: UseFormRegister<ProjectDetailsData>
   errors: FieldErrors<ProjectDetailsData>
 }
 
-const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelectContact, register, errors }) => {
+const ProjectDetails: React.FC<ProjectDetailsProps> = ({
+  data,
+  onChange,
+  onSelectContact,
+  onCopySiteAddress,
+  register,
+  errors
+}) => {
   const [selectedContactId, setSelectedContactId] = useState<string | null>(null)
   const [pendingUpdates, setPendingUpdates] = useState<Record<string, unknown>>({})
   const [updateMessage, setUpdateMessage] = useState<string | null>(null)
   const [updateError, setUpdateError] = useState<string | null>(null)
   const [projectNameCopied, setProjectNameCopied] = useState(false)
+  const [siteAddressCopied, setSiteAddressCopied] = useState(false)
   const handleFieldChange = (field: keyof ProjectDetailsData, rawValue: string) => {
     const value = field === 'projectName' ? toTitleCase(rawValue) : rawValue
     onChange(field, value)
@@ -90,6 +99,18 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
       setTimeout(() => setProjectNameCopied(false), 2000)
     } catch (err) {
       console.error('Failed to copy project name', err)
+    }
+  }
+
+  const handleCopySiteAddress = () => {
+    try {
+      const copied = onCopySiteAddress()
+      if (copied) {
+        setSiteAddressCopied(true)
+        setTimeout(() => setSiteAddressCopied(false), 2000)
+      }
+    } catch (err) {
+      console.error('Failed to copy site address', err)
     }
   }
 
@@ -269,16 +290,37 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ data, onChange, onSelec
           const field = register('siteAddress')
           return (
             <>
-              <input
-                type="text"
-                value={data.siteAddress}
-                onChange={(e) => {
-                  field.onChange(e)
-                  handleFieldChange('siteAddress', e.target.value)
-                }}
-                className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                placeholder="Enter site address"
-              />
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={data.siteAddress}
+                  onChange={(e) => {
+                    field.onChange(e)
+                    handleFieldChange('siteAddress', e.target.value)
+                  }}
+                  className="flex-1 min-w-0 px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                  placeholder="Enter site address"
+                />
+                <button
+                  type="button"
+                  onClick={handleCopySiteAddress}
+                  disabled={!data.siteAddress}
+                  className="flex items-center px-3 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors border border-accent disabled:opacity-50 whitespace-nowrap"
+                  aria-label="Copy site address to pickup location"
+                >
+                  {siteAddressCopied ? (
+                    <>
+                      <CheckCircle className="w-4 h-4 mr-1" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="w-4 h-4 mr-1" />
+                      Copy to Pickup
+                    </>
+                  )}
+                </button>
+              </div>
               {errors.siteAddress && (
                 <p className="text-red-500 text-xs mt-1">{String(errors.siteAddress.message)}</p>
               )}

--- a/src/lib/address.ts
+++ b/src/lib/address.ts
@@ -1,0 +1,143 @@
+export interface ParsedAddressParts {
+  street: string
+  city: string
+  state: string
+  zip: string
+}
+
+const toUpperState = (value: string | undefined) =>
+  value ? value.toUpperCase() : ''
+
+const createEmpty = (): ParsedAddressParts => ({
+  street: '',
+  city: '',
+  state: '',
+  zip: ''
+})
+
+/**
+ * Attempts to split a free-form address into street, city, state, and zip parts.
+ * The parser is tolerant of additional address segments (e.g., suite numbers)
+ * and gracefully falls back to returning the full address as the street when a
+ * segment cannot be determined.
+ */
+export const parseAddressParts = (address: string): ParsedAddressParts => {
+  if (!address) {
+    return createEmpty()
+  }
+
+  const normalized = address
+    .replace(/\s*\n+\s*/g, ', ')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+
+  if (!normalized) {
+    return createEmpty()
+  }
+
+  const segments = normalized
+    .split(',')
+    .map(segment => segment.trim())
+    .filter(Boolean)
+
+  if (segments.length === 0) {
+    return createEmpty()
+  }
+
+  if (segments.length === 1) {
+    return {
+      street: segments[0],
+      city: '',
+      state: '',
+      zip: ''
+    }
+  }
+
+  const streetSegments = [...segments]
+
+  const pop = () => streetSegments.pop()
+  const peek = () => streetSegments[streetSegments.length - 1]
+
+  let city = ''
+  let state = ''
+  let zip = ''
+
+  let last = peek()
+
+  if (!last) {
+    return createEmpty()
+  }
+
+  let match = last.match(/^([A-Za-z]{2})(?:\s+(\d{5}(?:-\d{4})?))?$/)
+  if (match) {
+    state = toUpperState(match[1])
+    if (match[2]) {
+      zip = match[2]
+    }
+    pop()
+    last = peek()
+  } else {
+    match = last.match(/^(\d{5}(?:-\d{4})?)$/)
+    if (match) {
+      zip = match[1]
+      pop()
+      last = peek()
+    }
+  }
+
+  if (last && (!state || !zip)) {
+    match = last.match(/^(.+?)\s+([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)$/)
+    if (match) {
+      city = match[1]
+      if (!state) state = toUpperState(match[2])
+      if (!zip) zip = match[3]
+      pop()
+      last = peek()
+    }
+  }
+
+  if (last && !state) {
+    match = last.match(/^([A-Za-z]{2})$/)
+    if (match) {
+      state = toUpperState(match[1])
+      pop()
+      last = peek()
+    }
+  }
+
+  if (last && !zip) {
+    match = last.match(/(\d{5}(?:-\d{4})?)$/)
+    if (match) {
+      zip = match[1]
+      const remainder = last.slice(0, last.length - match[1].length).trim()
+      if (remainder && !city) {
+        city = remainder.replace(/,+$/, '')
+      }
+      pop()
+      last = peek()
+    }
+  }
+
+  if (last && !city) {
+    match = last.match(/^(.+?)\s+([A-Za-z]{2})$/)
+    if (match) {
+      city = match[1]
+      if (!state) state = toUpperState(match[2])
+      pop()
+      last = peek()
+    }
+  }
+
+  if (!city && streetSegments.length) {
+    city = pop() ?? ''
+  }
+
+  const street = streetSegments.join(', ')
+
+  return {
+    street,
+    city,
+    state,
+    zip
+  }
+}

--- a/tests/ProjectDetails.test.tsx
+++ b/tests/ProjectDetails.test.tsx
@@ -31,6 +31,7 @@ describe('ProjectDetails copy button', () => {
         data={data}
         onChange={() => {}}
         onSelectContact={() => {}}
+        onCopySiteAddress={() => true}
         register={() => ({ onChange: () => {} }) as any}
         errors={{}}
       />
@@ -41,5 +42,38 @@ describe('ProjectDetails copy button', () => {
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('My Project')
     })
+  })
+
+  it('calls onCopySiteAddress when copy to pickup button is clicked', () => {
+    const copyHandler = vi.fn().mockReturnValue(true)
+
+    const data: ProjectDetailsData = {
+      projectName: '',
+      companyName: '',
+      contactName: '',
+      siteAddress: '123 Main St, Portland, OR 97205',
+      sitePhone: '',
+      shopLocation: '',
+      scopeOfWork: '',
+      email: ''
+    }
+
+    render(
+      <ProjectDetails
+        data={data}
+        onChange={() => {}}
+        onSelectContact={() => {}}
+        onCopySiteAddress={copyHandler}
+        register={() => ({ onChange: () => {} }) as any}
+        errors={{}}
+      />
+    )
+
+    const button = screen.getByRole('button', {
+      name: /copy site address to pickup location/i
+    })
+    fireEvent.click(button)
+
+    expect(copyHandler).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/addressParser.test.ts
+++ b/tests/addressParser.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { parseAddressParts } from '../src/lib/address'
+
+describe('parseAddressParts', () => {
+  it('parses a multi-line address into parts', () => {
+    const result = parseAddressParts('123 Main St\nPortland, OR 97205')
+
+    expect(result).toEqual({
+      street: '123 Main St',
+      city: 'Portland',
+      state: 'OR',
+      zip: '97205'
+    })
+  })
+
+  it('handles suite information in the street line', () => {
+    const result = parseAddressParts('123 Main St, Suite 200, Portland, OR 97205')
+
+    expect(result).toEqual({
+      street: '123 Main St, Suite 200',
+      city: 'Portland',
+      state: 'OR',
+      zip: '97205'
+    })
+  })
+
+  it('captures city and state when zip is unavailable', () => {
+    const result = parseAddressParts('123 Main St, Portland, OR')
+
+    expect(result).toEqual({
+      street: '123 Main St',
+      city: 'Portland',
+      state: 'OR',
+      zip: ''
+    })
+  })
+
+  it('returns blank parts when address is empty', () => {
+    expect(parseAddressParts('')).toEqual({
+      street: '',
+      city: '',
+      state: '',
+      zip: ''
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add an address parsing helper and use it so copying a site address fills pickup fields
- add a copy-to-pickup button beside the site address input and pass the handler through the equipment form
- cover the new parser and UI hook with unit tests

## Testing
- npm run lint *(fails due to pre-existing lint errors in the repo)*
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c9c025a7088321a81a5e50fa344faf