### PR TITLE
Add new rigging equipment options to equipment requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,11 @@ Encryption produces a value formatted as `iv:ciphertext`, where both parts are B
 - Lowboy
 - Step Deck
 
+### Material Handling & Rigging
+
+- Material Handler
+- 1-ton Gantry
+- 5-ton Gantry
+- 8'x20' Metal Plate
+- 8'x10' Metal Plate
+

--- a/src/components/EquipmentRequired.tsx
+++ b/src/components/EquipmentRequired.tsx
@@ -11,6 +11,7 @@ export interface EquipmentRequirements {
   forklifts: EquipmentItem[]
   tractors: EquipmentItem[]
   trailers: EquipmentItem[]
+  additionalEquipment: EquipmentItem[]
 }
 
 interface EquipmentRequiredProps {
@@ -34,6 +35,20 @@ const tractorOptions = ['3-axle tractor', '4-axle tractor', 'Rollback']
 
 const trailerOptions = ['Dovetail', 'Flatbed', 'Lowboy', 'Step Deck']
 
+const additionalEquipmentOptions = [
+  'Material Handler',
+  '1-ton Gantry',
+  '5-ton Gantry',
+  "8'x20' Metal Plate",
+  "8'x10' Metal Plate"
+]
+
+type EquipmentField =
+  | 'forklifts'
+  | 'tractors'
+  | 'trailers'
+  | 'additionalEquipment'
+
 const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange }) => {
   const handleFieldChange = <K extends keyof EquipmentRequirements>(
     field: K,
@@ -43,7 +58,7 @@ const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange })
   }
 
   const adjustQuantity = (
-    field: 'forklifts' | 'tractors' | 'trailers',
+    field: EquipmentField,
     name: string,
     delta: number
   ) => {
@@ -67,17 +82,23 @@ const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange })
   }
 
   const getQuantity = (
-    field: 'forklifts' | 'tractors' | 'trailers',
+    field: EquipmentField,
     name: string
   ) => data[field].find((i) => i.name === name)?.quantity || 0
 
   const clearSection = () => {
-    onChange({ crewSize: '', forklifts: [], tractors: [], trailers: [] })
+    onChange({
+      crewSize: '',
+      forklifts: [],
+      tractors: [],
+      trailers: [],
+      additionalEquipment: []
+    })
   }
 
   const renderOptionList = (
     label: string,
-    field: 'forklifts' | 'tractors' | 'trailers',
+    field: EquipmentField,
     options: string[]
   ) => (
     <div>
@@ -150,6 +171,7 @@ const EquipmentRequired: React.FC<EquipmentRequiredProps> = ({ data, onChange })
       {renderOptionList('Forklifts', 'forklifts', forkliftOptions)}
       {renderOptionList('Tractors', 'tractors', tractorOptions)}
       {renderOptionList('Trailers', 'trailers', trailerOptions)}
+      {renderOptionList('Material Handling & Rigging', 'additionalEquipment', additionalEquipmentOptions)}
     </div>
   )
 }

--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -87,6 +87,9 @@ export const generateScopeTemplate = (
   const forklifts = (equipmentRequirements.forklifts || []).filter((f: any) => f.quantity > 0)
   const tractors = (equipmentRequirements.tractors || []).filter((t: any) => t.quantity > 0)
   const trailers = (equipmentRequirements.trailers || []).filter((t: any) => t.quantity > 0)
+  const additionalEquipment = (equipmentRequirements.additionalEquipment || []).filter(
+    (item: any) => item.quantity > 0
+  )
 
   const formatEquipmentItem = (quantity: number, name: string) => {
     const needsPlural = quantity > 1 && !name.toLowerCase().endsWith('s')
@@ -110,7 +113,8 @@ export const generateScopeTemplate = (
           ? t.name
           : `${t.name} trailer`
       )
-    )
+    ),
+    ...additionalEquipment.map((item: any) => formatEquipmentItem(item.quantity, item.name))
   ].filter(Boolean)
 
   const equipmentSummary = (() => {

--- a/src/components/QuoteHistoryModal.tsx
+++ b/src/components/QuoteHistoryModal.tsx
@@ -158,13 +158,17 @@ const QuoteHistoryModal: React.FC<QuoteHistoryModalProps> = ({
           email: '',
         }
 
-        const loadedRequirements =
-          quote.equipment_requirements || {
-            crewSize: '',
-            forklifts: [],
-            tractors: [],
-            trailers: []
-          }
+        const defaultRequirements = {
+          crewSize: '',
+          forklifts: [],
+          tractors: [],
+          trailers: [],
+          additionalEquipment: []
+        }
+
+        const loadedRequirements = quote.equipment_requirements
+          ? { ...defaultRequirements, ...quote.equipment_requirements }
+          : defaultRequirements
 
         const loadedLogisticsData = {
           ...(quote.logistics_data || {}),

--- a/src/components/QuoteSaveManager.tsx
+++ b/src/components/QuoteSaveManager.tsx
@@ -151,13 +151,17 @@ const QuoteSaveManager: React.FC<QuoteSaveManagerProps> = ({
           email: '',
         }
 
-        const loadedRequirements =
-          quote.equipment_requirements || {
-            crewSize: '',
-            forklifts: [],
-            tractors: [],
-            trailers: []
-          }
+        const defaultRequirements = {
+          crewSize: '',
+          forklifts: [],
+          tractors: [],
+          trailers: [],
+          additionalEquipment: []
+        }
+
+        const loadedRequirements = quote.equipment_requirements
+          ? { ...defaultRequirements, ...quote.equipment_requirements }
+          : defaultRequirements
 
         const loadedLogisticsData = {
           ...(quote.logistics_data || {}),

--- a/src/components/__tests__/EquipmentForm.test.tsx
+++ b/src/components/__tests__/EquipmentForm.test.tsx
@@ -16,7 +16,13 @@ test('EquipmentForm renders Equipment Quote heading', () => {
     shopLocation: 'Shop',
     scopeOfWork: '',
     email: '',
-    equipmentRequirements: { crewSize: '', forklifts: [], tractors: [], trailers: [] } as EquipmentRequirements
+    equipmentRequirements: {
+      crewSize: '',
+      forklifts: [],
+      tractors: [],
+      trailers: [],
+      additionalEquipment: []
+    } as EquipmentRequirements
   };
 
   const html = renderToString(

--- a/src/hooks/useEquipmentForm.ts
+++ b/src/hooks/useEquipmentForm.ts
@@ -7,7 +7,8 @@ export const useEquipmentForm = () => {
     crewSize: '',
     forklifts: [],
     tractors: [],
-    trailers: []
+    trailers: [],
+    additionalEquipment: []
   };
 
   const initialEquipmentData = {

--- a/tests/quoteService.test.ts
+++ b/tests/quoteService.test.ts
@@ -20,7 +20,13 @@ const equipmentData: EquipmentData = {
   shopLocation: '',
   scopeOfWork: '',
   email: '',
-  equipmentRequirements: { crewSize: '', forklifts: [], tractors: [], trailers: [] } as EquipmentRequirements
+  equipmentRequirements: {
+    crewSize: '',
+    forklifts: [],
+    tractors: [],
+    trailers: [],
+    additionalEquipment: []
+  } as EquipmentRequirements
 }
 
 const logisticsData: LogisticsData = {
@@ -31,7 +37,13 @@ const logisticsData: LogisticsData = {
   storage: null
 }
 
-const equipmentRequirements: EquipmentRequirements = { crewSize: '', forklifts: [], tractors: [], trailers: [] }
+const equipmentRequirements: EquipmentRequirements = {
+  crewSize: '',
+  forklifts: [],
+  tractors: [],
+  trailers: [],
+  additionalEquipment: []
+}
 
 beforeEach(() => {
   vi.clearAllMocks()


### PR DESCRIPTION
## Summary
- add material handling and rigging options to the equipment requirements selector and support state resets
- ensure saved quotes load the new equipment field and include it in preview summaries
- document the new equipment choices for reference

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf980ee288321868df74dc5d33a3b