### PR TITLE
Add 12k Reach forklift option

### DIFF
--- a/src/components/EquipmentRequired.tsx
+++ b/src/components/EquipmentRequired.tsx
@@ -29,6 +29,7 @@ const forkliftOptions = [
   'Versalift 40/60',
   'Versalift 60/80',
   'Trilifter',
+  'Forklift (12k Reach)',
 ]
 
 const tractorOptions = ['3-axle tractor', '4-axle tractor', 'Rollback']


### PR DESCRIPTION
## Summary
- add a 12k Reach forklift option to the selectable forklift equipment list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2bd5eb91883218d9b9a9de96d3cf8