### PR TITLE
Add lift platform option to rigging equipment list

### DIFF
--- a/src/components/EquipmentRequired.tsx
+++ b/src/components/EquipmentRequired.tsx
@@ -41,7 +41,8 @@ const additionalEquipmentOptions = [
   '1-ton Gantry',
   '5-ton Gantry',
   "8'x20' Metal Plate",
-  "8'x10' Metal Plate"
+  "8'x10' Metal Plate",
+  'Lift Platform'
 ]
 
 type EquipmentField =


### PR DESCRIPTION
## Summary
- add Lift Platform to the Material Handling & Rigging equipment options

## Testing
- npm run lint *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bf67263c83218e0b577bb6fd8a17