### PR TITLE
Capitalize site contact name and reorder forklift options

### DIFF
--- a/src/components/EquipmentRequired.tsx
+++ b/src/components/EquipmentRequired.tsx
@@ -24,12 +24,12 @@ const forkliftOptions = [
   'Forklift (8k)',
   'Forklift (15k)',
   'Forklift (30k)',
+  'Forklift (12k Reach)',
   'Forklift – Hoist 18/26',
   'Versalift 25/35',
   'Versalift 40/60',
   'Versalift 60/80',
   'Trilifter',
-  'Forklift (12k Reach)',
 ]
 
 const tractorOptions = ['3-axle tractor', '4-axle tractor', 'Rollback']

--- a/src/components/ProjectDetails.tsx
+++ b/src/components/ProjectDetails.tsx
@@ -52,7 +52,10 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({
   const [siteAddressCopied, setSiteAddressCopied] = useState(false)
   const [companyNameCopied, setCompanyNameCopied] = useState(false)
   const handleFieldChange = (field: keyof ProjectDetailsData, rawValue: string) => {
-    const value = field === 'projectName' ? toTitleCase(rawValue) : rawValue
+    const value =
+      field === 'projectName' || field === 'contactName'
+        ? toTitleCase(rawValue)
+        : rawValue
     onChange(field, value)
     if (selectedContactId) {
       setPendingUpdates(prev => {
@@ -265,8 +268,10 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({
                   type="text"
                   value={data.contactName}
                   onChange={(e) => {
+                    const formattedValue = toTitleCase(e.target.value)
+                    e.target.value = formattedValue
                     field.onChange(e)
-                    handleFieldChange('contactName', e.target.value)
+                    handleFieldChange('contactName', formattedValue)
                   }}
                   className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
                   placeholder="Enter site contact"


### PR DESCRIPTION
## Summary
- normalize the site contact field to title case when edited so contact names are capitalized automatically
- move the 12k reach forklift option directly beneath the 30k forklift in the equipment requirements list

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2c04b29ec83218b71541e2d1ea04a