### PR TITLE
Include gear truck and trailer in scope template

### DIFF
--- a/src/components/PreviewTemplates.tsx
+++ b/src/components/PreviewTemplates.tsx
@@ -135,6 +135,7 @@ export const generateScopeTemplate = (
 
   const equipmentItems = [
     crewDescription,
+    'gear truck and trailer',
     ...forklifts.map((f: any) => formatEquipmentItem(f.quantity, f.name)),
     ...tractors.map((t: any) => formatEquipmentItem(t.quantity, t.name)),
     ...trailers.map((t: any) =>


### PR DESCRIPTION
## Summary
- ensure the scope of work template always lists a gear truck and trailer immediately after the crew description

## Testing
- `npm run lint` *(fails: existing lint errors related to missing dependencies and explicit any types)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c1d063348321bba098543c4200dd