### PR TITLE
Add None shipment type option and conditional logistics UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,6 +238,7 @@ const App: React.FC = () => {
   const { subject: logisticsSubject, body: logisticsBody } =
     generateLogisticsEmail(equipmentData, logisticsData)
   const logisticsTemplate = `${logisticsSubject}\n\n${logisticsBody}`
+  const showLogisticsTemplate = Boolean(logisticsData.shipmentType)
 
   const copyToClipboard = async (
     text: string,
@@ -398,44 +399,46 @@ const App: React.FC = () => {
             </div>
           </div>
 
-          <div className="bg-gray-900 rounded-lg border-2 border-accent p-6">
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center">
-                <Truck className="w-6 h-6 text-white mr-2" />
-                <h2 className="text-2xl font-bold text-white">Logistics Email Template</h2>
+          {showLogisticsTemplate && (
+            <div className="bg-gray-900 rounded-lg border-2 border-accent p-6">
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center">
+                  <Truck className="w-6 h-6 text-white mr-2" />
+                  <h2 className="text-2xl font-bold text-white">Logistics Email Template</h2>
+                </div>
+                <div className="flex gap-2">
+                  <a
+                    href={`mailto:Logistics@omegamorgan.com; MachineryLogistics@omegamorgan.com?subject=${encodeURIComponent(logisticsSubject)}&body=${encodeURIComponent(logisticsBody)}`}
+                    className="flex items-center px-4 py-2 bg-accent text-black rounded-lg hover:bg-green-400 transition-colors"
+                  >
+                    <Mail className="w-4 h-4 mr-2" />
+                    Email
+                  </a>
+                  <button
+                    onClick={() => copyToClipboard(logisticsTemplate, 'logistics')}
+                    className="flex items-center px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors border border-accent"
+                  >
+                    {copiedTemplate === 'logistics' ? (
+                      <>
+                        <CheckCircle className="w-4 h-4 mr-2" />
+                        Copied!
+                      </>
+                    ) : (
+                      <>
+                        <Copy className="w-4 h-4 mr-2" />
+                        Copy
+                      </>
+                    )}
+                  </button>
+                </div>
               </div>
-              <div className="flex gap-2">
-                <a
-                  href={`mailto:Logistics@omegamorgan.com; MachineryLogistics@omegamorgan.com?subject=${encodeURIComponent(logisticsSubject)}&body=${encodeURIComponent(logisticsBody)}`}
-                  className="flex items-center px-4 py-2 bg-accent text-black rounded-lg hover:bg-green-400 transition-colors"
-                >
-                  <Mail className="w-4 h-4 mr-2" />
-                  Email
-                </a>
-                <button
-                  onClick={() => copyToClipboard(logisticsTemplate, 'logistics')}
-                  className="flex items-center px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors border border-accent"
-                >
-                  {copiedTemplate === 'logistics' ? (
-                    <>
-                      <CheckCircle className="w-4 h-4 mr-2" />
-                      Copied!
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="w-4 h-4 mr-2" />
-                      Copy
-                    </>
-                  )}
-                </button>
+              <div className="bg-black rounded-lg p-4 border border-accent">
+                <pre className="whitespace-pre-wrap text-sm text-white font-mono leading-relaxed">
+                  {logisticsTemplate}
+                </pre>
               </div>
             </div>
-            <div className="bg-black rounded-lg p-4 border border-accent">
-              <pre className="whitespace-pre-wrap text-sm text-white font-mono leading-relaxed">
-                {logisticsTemplate}
-              </pre>
-            </div>
-          </div>
+          )}
         </div>
 
         {/* Clarifications */}

--- a/src/components/LogisticsForm.tsx
+++ b/src/components/LogisticsForm.tsx
@@ -401,11 +401,16 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
                 <select
                   value={data.shipmentType}
                   onChange={(e) => {
+                    const value = e.target.value
                     field.onChange(e)
-                    onFieldChange('shipmentType', e.target.value)
+                    onFieldChange('shipmentType', value)
+                    if (!value) {
+                      onFieldChange('truckType', '')
+                    }
                   }}
                   className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
                 >
+                  <option value="">None</option>
                   <option value="LTL">LTL</option>
                   <option value="FTL">FTL</option>
                 </select>
@@ -418,32 +423,34 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
         </div>
 
         {/* Truck Type Requested */}
-        <div>
-          <label className="block text-sm font-medium text-white mb-2">Truck Type Requested</label>
-          {(() => {
-            const field = register('truckType')
-            return (
-              <>
-                <select
-                  value={data.truckType}
-                  onChange={(e) => {
-                    field.onChange(e)
-                    onFieldChange('truckType', e.target.value)
-                  }}
-                  className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
-                >
-                  <option value="">Select truck type</option>
-                  <option value="Flatbed">Flatbed</option>
-                  <option value="Flatbed with tarp">Flatbed with tarp</option>
-                  <option value="Conestoga">Conestoga</option>
-                </select>
-                {errors.truckType && (
-                  <p className="text-red-500 text-xs mt-1">{String(errors.truckType.message)}</p>
-                )}
-              </>
-            )
-          })()}
-        </div>
+        {data.shipmentType && (
+          <div>
+            <label className="block text-sm font-medium text-white mb-2">Truck Type Requested</label>
+            {(() => {
+              const field = register('truckType')
+              return (
+                <>
+                  <select
+                    value={data.truckType}
+                    onChange={(e) => {
+                      field.onChange(e)
+                      onFieldChange('truckType', e.target.value)
+                    }}
+                    className="w-full px-3 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white"
+                  >
+                    <option value="">Select truck type</option>
+                    <option value="Flatbed">Flatbed</option>
+                    <option value="Flatbed with tarp">Flatbed with tarp</option>
+                    <option value="Conestoga">Conestoga</option>
+                  </select>
+                  {errors.truckType && (
+                    <p className="text-red-500 text-xs mt-1">{String(errors.truckType.message)}</p>
+                  )}
+                </>
+              )
+            })()}
+          </div>
+        )}
 
         {/* Storage Requirements */}
         <div>

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -33,8 +33,14 @@ export const logisticsSchema = yup.object({
   deliveryCity: yup.string().required('Delivery city is required'),
   deliveryState: yup.string().required('Delivery state is required'),
   deliveryZip: yup.string().required('Delivery zip is required'),
-  shipmentType: yup.string().required('Shipment type is required'),
-  truckType: yup.string().required('Truck type is required'),
+  shipmentType: yup
+    .string()
+    .oneOf(['', 'LTL', 'FTL'], 'Invalid shipment type'),
+  truckType: yup.string().when('shipmentType', {
+    is: (val: string) => val && val !== '',
+    then: schema => schema.required('Truck type is required'),
+    otherwise: schema => schema
+  }),
   storageType: yup.string(),
   storageSqFt: yup.string().when('storageType', {
     is: (val: string) => val && val !== '',


### PR DESCRIPTION
## Summary
- add a "None" option to the shipment type selector and clear truck type when chosen
- hide the truck type selector and logistics email template when no shipment type is selected
- update validation to only require truck type when a shipment type is provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2e97700848321aa2cf523b8e78b04