### PR TITLE
Add stable IDs and reordering for logistics pieces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { EquipmentData, LogisticsData } from './types'
 import { useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { equipmentSchema, logisticsSchema } from './lib/validation'
+import { createLogisticsPiece } from './lib/logisticsPieces'
 import { parseAddressParts } from './lib/address'
 import { HubSpotContact } from './services/hubspotService'
 
@@ -57,7 +58,8 @@ const App: React.FC = () => {
     addPiece,
     removePiece,
     togglePieceSelection,
-    deleteSelectedPieces
+    deleteSelectedPieces,
+    movePiece
   } = useLogisticsForm()
 
   const equipmentForm = useForm<EquipmentData>({
@@ -164,14 +166,17 @@ const App: React.FC = () => {
       
       // Map pieces data
       if (extractedLogisticsData.pieces && Array.isArray(extractedLogisticsData.pieces)) {
-        mappedLogisticsData.pieces = extractedLogisticsData.pieces.map(piece => ({
-          description: piece.description || '',
-          quantity: piece.quantity || 1,
-          length: piece.length?.toString() || '',
-          width: piece.width?.toString() || '',
-          height: piece.height?.toString() || '',
-          weight: piece.weight?.toString() || ''
-        }))
+        mappedLogisticsData.pieces = extractedLogisticsData.pieces.map(piece =>
+          createLogisticsPiece({
+            id: piece.id,
+            description: piece.description || '',
+            quantity: piece.quantity || 1,
+            length: piece.length?.toString() || '',
+            width: piece.width?.toString() || '',
+            height: piece.height?.toString() || '',
+            weight: piece.weight?.toString() || ''
+          })
+        )
       }
       
       // Map address data
@@ -205,7 +210,10 @@ const App: React.FC = () => {
       shipmentType: '',
       storageType: '',
       storageSqFt: '',
-      ...loadedLogisticsData
+      ...loadedLogisticsData,
+      pieces: loadedLogisticsData.pieces
+        ? loadedLogisticsData.pieces.map(piece => createLogisticsPiece(piece))
+        : loadedLogisticsData.pieces
     })
   }
 
@@ -332,6 +340,7 @@ const App: React.FC = () => {
             removePiece={removePiece}
             togglePieceSelection={togglePieceSelection}
             deleteSelectedPieces={deleteSelectedPieces}
+            movePiece={movePiece}
             register={logisticsForm.register}
             errors={logisticsForm.formState.errors}
           />

--- a/src/components/LogisticsForm.tsx
+++ b/src/components/LogisticsForm.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { Truck, Package, Plus, Minus, Trash2 } from 'lucide-react'
+import { Truck, Package, Plus, Minus, Trash2, ArrowUp, ArrowDown } from 'lucide-react'
 import { UseFormRegister, FieldErrors } from 'react-hook-form'
 
 interface Piece {
+  id: string;
   description: string;
   quantity: number;
   length: string;
@@ -29,7 +30,7 @@ interface LogisticsData {
 
 interface LogisticsFormProps {
   data: LogisticsData;
-  selectedPieces: number[];
+  selectedPieces: string[];
   onFieldChange: (field: string, value: string) => void;
   onPieceChange: (
     index: number,
@@ -37,9 +38,10 @@ interface LogisticsFormProps {
     value: string | number
   ) => void;
   addPiece: () => void;
-  removePiece: (index: number) => void;
-  togglePieceSelection: (index: number) => void;
+  removePiece: (pieceId: string) => void;
+  togglePieceSelection: (pieceId: string) => void;
   deleteSelectedPieces: () => void;
+  movePiece: (oldIndex: number, newIndex: number) => void;
   register: UseFormRegister<LogisticsData>;
   errors: FieldErrors<LogisticsData>;
 }
@@ -53,6 +55,7 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
   removePiece,
   togglePieceSelection,
   deleteSelectedPieces,
+  movePiece,
   register,
   errors
 }) => {
@@ -92,12 +95,12 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
 
           <div className="space-y-3">
             {data.pieces.map((piece, index) => (
-              <div key={index} className="grid grid-cols-12 gap-2 items-end">
+              <div key={piece.id} className="grid grid-cols-12 gap-2 items-end">
                 <div className="col-span-1 flex justify-center">
                   <input
                     type="checkbox"
-                    checked={selectedPieces.includes(index)}
-                    onChange={() => togglePieceSelection(index)}
+                    checked={selectedPieces.includes(piece.id)}
+                    onChange={() => togglePieceSelection(piece.id)}
                     className="form-checkbox h-4 w-4 text-accent"
                   />
                 </div>
@@ -197,14 +200,33 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
                   })()}
                 </div>
                 <div className="col-span-1">
-                  {data.pieces.length > 1 && (
+                  <div className="flex flex-col gap-1">
                     <button
-                      onClick={() => removePiece(index)}
-                      className="w-full p-2 bg-red-600 text-white rounded-lg hover:bg-red-500 transition-colors"
+                      type="button"
+                      onClick={() => movePiece(index, index - 1)}
+                      disabled={index === 0}
+                      className="p-2 bg-gray-800 text-white rounded-lg hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      <Minus className="w-4 h-4" />
+                      <ArrowUp className="w-4 h-4" />
                     </button>
-                  )}
+                    <button
+                      type="button"
+                      onClick={() => movePiece(index, index + 1)}
+                      disabled={index === data.pieces.length - 1}
+                      className="p-2 bg-gray-800 text-white rounded-lg hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <ArrowDown className="w-4 h-4" />
+                    </button>
+                    {data.pieces.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => removePiece(piece.id)}
+                        className="p-2 bg-red-600 text-white rounded-lg hover:bg-red-500 transition-colors"
+                      >
+                        <Minus className="w-4 h-4" />
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
             ))}

--- a/src/components/__tests__/LogisticsForm.test.tsx
+++ b/src/components/__tests__/LogisticsForm.test.tsx
@@ -6,7 +6,17 @@ import LogisticsForm from '../LogisticsForm';
 
 test('LogisticsForm renders Logistics Quote heading', () => {
   const data = {
-    pieces: [{ description: '', quantity: 1, length: '', width: '', height: '', weight: '' }],
+    pieces: [
+      {
+        id: 'piece-1',
+        description: '',
+        quantity: 1,
+        length: '',
+        width: '',
+        height: '',
+        weight: ''
+      }
+    ],
     pickupAddress: '',
     pickupCity: '',
     pickupState: '',
@@ -31,6 +41,7 @@ test('LogisticsForm renders Logistics Quote heading', () => {
       removePiece={() => {}}
       togglePieceSelection={() => {}}
       deleteSelectedPieces={() => {}}
+      movePiece={() => {}}
       register={() => ({ onChange: () => {}, onBlur: () => {}, ref: () => {} }) as any}
       errors={{}}
     />

--- a/src/lib/logisticsPieces.ts
+++ b/src/lib/logisticsPieces.ts
@@ -1,0 +1,34 @@
+import type { LogisticsPiece } from '../types'
+
+let pieceIdCounter = 0
+
+export const generatePieceId = () => {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID()
+  }
+
+  pieceIdCounter += 1
+  return `piece-${Date.now()}-${pieceIdCounter}`
+}
+
+export const createLogisticsPiece = (
+  piece?: Partial<LogisticsPiece>
+): LogisticsPiece => ({
+  id: piece?.id ?? generatePieceId(),
+  description: piece?.description ?? '',
+  quantity: piece?.quantity ?? 1,
+  length: piece?.length ?? '',
+  width: piece?.width ?? '',
+  height: piece?.height ?? '',
+  weight: piece?.weight ?? ''
+})
+
+export const normalizePieces = (
+  pieces?: Partial<LogisticsPiece>[]
+): LogisticsPiece[] => {
+  if (!pieces || pieces.length === 0) {
+    return [createLogisticsPiece()]
+  }
+
+  return pieces.map(piece => createLogisticsPiece(piece))
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,6 +1,7 @@
 import * as yup from 'yup'
 
 export const pieceSchema = yup.object({
+  id: yup.string().required('Piece id is required'),
   description: yup.string().required('Description is required'),
   quantity: yup
     .number()

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface EquipmentData {
 }
 
 export interface LogisticsPiece {
+  id: string
   description: string
   quantity: number
   length: string

--- a/tests/useLogisticsForm.test.ts
+++ b/tests/useLogisticsForm.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import useLogisticsForm from '../src/hooks/useLogisticsForm'
+
+describe('useLogisticsForm', () => {
+  it('movePiece reorders pieces while preserving selection', () => {
+    const { result } = renderHook(() => useLogisticsForm())
+
+    act(() => {
+      result.current.addPiece()
+      result.current.addPiece()
+    })
+
+    const initialOrder = result.current.logisticsData.pieces.map(piece => piece.id)
+
+    act(() => {
+      result.current.togglePieceSelection(initialOrder[0])
+    })
+
+    act(() => {
+      result.current.movePiece(0, 2)
+    })
+
+    expect(result.current.logisticsData.pieces[2].id).toBe(initialOrder[0])
+    expect(result.current.selectedPieces).toContain(initialOrder[0])
+  })
+})

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -22,6 +22,7 @@ describe('validation schemas', () => {
   it('pieceSchema rejects quantity below 1', async () => {
     await expect(
       pieceSchema.validate({
+        id: 'piece-1',
         description: 'test',
         quantity: 0,
         length: '1',
@@ -35,7 +36,15 @@ describe('validation schemas', () => {
   it('logisticsSchema rejects when missing pickup address', async () => {
     await expect(
       logisticsSchema.validate({
-        pieces: [{ description: 'a', quantity: 1, length: '1', width: '1', height: '1', weight: '1' }],
+        pieces: [{
+          id: 'piece-1',
+          description: 'a',
+          quantity: 1,
+          length: '1',
+          width: '1',
+          height: '1',
+          weight: '1'
+        }],
         pickupAddress: '',
         pickupCity: 'c',
         pickupState: 's',


### PR DESCRIPTION
## Summary
- assign stable ids to logistics pieces, normalize incoming data, and keep selection synced with reordering
- update the logistics form UI to use piece ids, surface move controls, and ensure downstream templates receive the reordered data
- require piece ids in validation/types and add coverage for the new movePiece helper

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b7f992688321948862ea40873760