### PR TITLE
Add 20k reach forklift option

### DIFF
--- a/src/components/EquipmentRequired.tsx
+++ b/src/components/EquipmentRequired.tsx
@@ -25,6 +25,7 @@ const forkliftOptions = [
   'Forklift (15k)',
   'Forklift (30k)',
   'Forklift (12k Reach)',
+  'Forklift (20k Reach)',
   'Forklift – Hoist 18/26',
   'Versalift 25/35',
   'Versalift 40/60',


### PR DESCRIPTION
## Summary
- add a 20k reach forklift to the available forklift options in the equipment requirements form

## Testing
- npm test -- --run tests

------
https://chatgpt.com/codex/tasks/task_e_68d5c1f0cb348321af27f23e3295843e