### PR TITLE
Adjust logistics weight controls layout

### DIFF
--- a/src/components/LogisticsForm.tsx
+++ b/src/components/LogisticsForm.tsx
@@ -177,56 +177,56 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
                     placeholder="H"
                   />
                 </div>
-                <div className="col-span-2">
-                  {(() => {
-                    const field = register(`pieces.${index}.weight` as const)
-                    return (
-                      <>
-                        <input
-                          type="text"
-                          value={piece.weight}
-                          onChange={(e) => {
-                            field.onChange(e)
-                            onPieceChange(index, 'weight', e.target.value)
-                          }}
-                          className="w-full px-2 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm"
-                          placeholder="Weight (lbs)"
-                        />
-                        {errors.pieces?.[index]?.weight && (
-                          <p className="text-red-500 text-xs mt-1">{String(errors.pieces[index]?.weight?.message)}</p>
-                        )}
-                      </>
-                    )
-                  })()}
-                </div>
-                <div className="col-span-2">
-                  <div className="flex items-stretch gap-2">
-                    {data.pieces.length > 1 && (
-                      <button
-                        type="button"
-                        onClick={() => removePiece(piece.id)}
-                        className="flex-1 h-5 bg-red-600 text-white rounded-lg hover:bg-red-500 transition-colors flex items-center justify-center"
-                      >
-                        <Minus className="w-3 h-3" />
-                      </button>
-                    )}
-                    <div className={`flex h-5 ${data.pieces.length > 1 ? 'flex-1' : 'w-full'} bg-gray-800 text-white rounded-lg overflow-hidden`}>
-                      <button
-                        type="button"
-                        onClick={() => movePiece(index, index - 1)}
-                        disabled={index === 0}
-                        className="flex-1 flex items-center justify-center hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        <ArrowUp className="w-3 h-3" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => movePiece(index, index + 1)}
-                        disabled={index === data.pieces.length - 1}
-                        className="flex-1 flex items-center justify-center hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        <ArrowDown className="w-3 h-3" />
-                      </button>
+                <div className="col-span-3">
+                  <div className="flex items-start gap-2">
+                    {(() => {
+                      const field = register(`pieces.${index}.weight` as const)
+                      return (
+                        <div className="flex-1">
+                          <input
+                            type="text"
+                            value={piece.weight}
+                            onChange={(e) => {
+                              field.onChange(e)
+                              onPieceChange(index, 'weight', e.target.value)
+                            }}
+                            className="w-full px-2 py-1 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm"
+                            placeholder="Weight (lbs)"
+                          />
+                          {errors.pieces?.[index]?.weight && (
+                            <p className="text-red-500 text-xs mt-1">{String(errors.pieces[index]?.weight?.message)}</p>
+                          )}
+                        </div>
+                      )
+                    })()}
+                    <div className="flex items-center gap-2 pt-0.5">
+                      {data.pieces.length > 1 && (
+                        <button
+                          type="button"
+                          onClick={() => removePiece(piece.id)}
+                          className="px-2 py-1 bg-red-600 text-white rounded-lg hover:bg-red-500 transition-colors flex items-center justify-center"
+                        >
+                          <Minus className="w-3 h-3" />
+                        </button>
+                      )}
+                      <div className="flex flex-col bg-gray-800 text-white rounded-lg overflow-hidden">
+                        <button
+                          type="button"
+                          onClick={() => movePiece(index, index - 1)}
+                          disabled={index === 0}
+                          className="flex items-center justify-center px-2 py-1 hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          <ArrowUp className="w-3 h-3" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => movePiece(index, index + 1)}
+                          disabled={index === data.pieces.length - 1}
+                          className="flex items-center justify-center px-2 py-1 hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          <ArrowDown className="w-3 h-3" />
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- reduce the vertical padding of the weight input and rearrange the column widths
- align the delete and reorder buttons on the same row as the weight input for each logistics piece

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d5c2ff3b8c8321b8de31dc1e3e0153