### PR TITLE
Align weight input with other piece fields

### DIFF
--- a/src/components/LogisticsForm.tsx
+++ b/src/components/LogisticsForm.tsx
@@ -177,57 +177,55 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
                     placeholder="H"
                   />
                 </div>
-                <div className="col-span-3">
-                  <div className="flex items-start gap-2">
-                    {(() => {
-                      const field = register(`pieces.${index}.weight` as const)
-                      return (
-                        <div className="w-full max-w-[50%] min-w-[8rem]">
-                          <input
-                            type="text"
-                            value={piece.weight}
-                            onChange={(e) => {
-                              field.onChange(e)
-                              onPieceChange(index, 'weight', e.target.value)
-                            }}
-                            className="w-full px-2 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm"
-                            placeholder="Weight (lbs)"
-                          />
-                          {errors.pieces?.[index]?.weight && (
-                            <p className="text-red-500 text-xs mt-1">{String(errors.pieces[index]?.weight?.message)}</p>
-                          )}
-                        </div>
-                      )
-                    })()}
-                    <div className="flex items-center gap-2 pt-0.5">
-                      {data.pieces.length > 1 && (
-                        <button
-                          type="button"
-                          onClick={() => removePiece(piece.id)}
-                          className="px-2 py-1 bg-red-600 text-white rounded-lg hover:bg-red-500 transition-colors flex items-center justify-center"
-                        >
-                          <Minus className="w-3 h-3" />
-                        </button>
-                      )}
-                      <div className="flex flex-col bg-gray-800 text-white rounded-lg overflow-hidden">
-                        <button
-                          type="button"
-                          onClick={() => movePiece(index, index - 1)}
-                          disabled={index === 0}
-                          className="flex items-center justify-center px-2 py-1 hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          <ArrowUp className="w-3 h-3" />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => movePiece(index, index + 1)}
-                          disabled={index === data.pieces.length - 1}
-                          className="flex items-center justify-center px-2 py-1 hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          <ArrowDown className="w-3 h-3" />
-                        </button>
+                <div className="col-span-1">
+                  {(() => {
+                    const field = register(`pieces.${index}.weight` as const)
+                    return (
+                      <div>
+                        <input
+                          type="text"
+                          value={piece.weight}
+                          onChange={(e) => {
+                            field.onChange(e)
+                            onPieceChange(index, 'weight', e.target.value)
+                          }}
+                          className="w-full px-2 py-2 bg-black border border-accent rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent text-white text-sm"
+                          placeholder="Weight (lbs)"
+                        />
+                        {errors.pieces?.[index]?.weight && (
+                          <p className="text-red-500 text-xs mt-1">{String(errors.pieces[index]?.weight?.message)}</p>
+                        )}
                       </div>
-                    </div>
+                    )
+                  })()}
+                </div>
+                <div className="col-span-2 flex items-center gap-2">
+                  {data.pieces.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => removePiece(piece.id)}
+                      className="px-2 py-1 bg-red-600 text-white rounded-lg hover:bg-red-500 transition-colors flex items-center justify-center"
+                    >
+                      <Minus className="w-3 h-3" />
+                    </button>
+                  )}
+                  <div className="flex flex-col bg-gray-800 text-white rounded-lg overflow-hidden">
+                    <button
+                      type="button"
+                      onClick={() => movePiece(index, index - 1)}
+                      disabled={index === 0}
+                      className="flex items-center justify-center px-2 py-1 hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <ArrowUp className="w-3 h-3" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => movePiece(index, index + 1)}
+                      disabled={index === data.pieces.length - 1}
+                      className="flex items-center justify-center px-2 py-1 hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <ArrowDown className="w-3 h-3" />
+                    </button>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- align the weight field with the other item dimension inputs in the logistics form grid
- move the piece controls into their own column so the weight textbox remains inline and consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c82514d08321900f0396a8f79693