### PR TITLE
Use ApiKeyService in useApiKey hook and add unit test

### DIFF
--- a/src/hooks/useApiKey.ts
+++ b/src/hooks/useApiKey.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { ApiKeyService } from '../services/apiKeyService'
 
 export const useApiKey = () => {
   const [hasApiKey, setHasApiKey] = useState(false)
@@ -9,10 +10,9 @@ export const useApiKey = () => {
     try {
       setLoading(true)
       setError(null)
-      
-      // Check if VITE_OPENAI_API_KEY is configured in environment
-      const hasKey = !!import.meta.env.VITE_OPENAI_API_KEY
-      console.log('API Key check:', { hasKey, envVar: import.meta.env.VITE_OPENAI_API_KEY ? 'present' : 'missing' })
+
+      const hasKey = await ApiKeyService.hasApiKey()
+      console.log('API Key check:', { hasKey })
       setHasApiKey(hasKey)
     } catch (err) {
       console.error('Error checking API key:', err)

--- a/tests/useApiKey.test.ts
+++ b/tests/useApiKey.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+let useApiKey: typeof import('../src/hooks/useApiKey').useApiKey
+let ApiKeyService: typeof import('../src/services/apiKeyService').ApiKeyService
+
+beforeAll(async () => {
+  vi.stubEnv('VITE_SUPABASE_URL', 'http://localhost')
+  vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key')
+
+  ;({ useApiKey } = await import('../src/hooks/useApiKey'))
+  ;({ ApiKeyService } = await import('../src/services/apiKeyService'))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterAll(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('useApiKey', () => {
+  it('reports hasApiKey=true when ApiKeyService resolves truthy', async () => {
+    vi.spyOn(ApiKeyService, 'hasApiKey').mockResolvedValue(true)
+
+    const { result } = renderHook(() => useApiKey())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.hasApiKey).toBe(true)
+    expect(result.current.error).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- update the `useApiKey` hook to call `ApiKeyService.hasApiKey` instead of reading from environment variables
- preserve the hook's error handling and refetch behavior while logging the service result
- add a unit test that stubs Supabase env vars, mocks `ApiKeyService.hasApiKey`, and expects `hasApiKey` to be true when the service resolves truthy

## Testing
- npx vitest run tests/useApiKey.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd66efe2b083218ca6a4d8f6ab9d3a