### PR TITLE
Improve HubSpot contact address handling for equipment form

### DIFF
--- a/src/hooks/useEquipmentForm.ts
+++ b/src/hooks/useEquipmentForm.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { HubSpotContact } from '../services/hubspotService';
+import { formatAddressFromParts } from '../lib/address';
 import { EquipmentRequirements } from '../components/EquipmentRequired';
 
 export const useEquipmentForm = () => {
@@ -34,13 +35,50 @@ export const useEquipmentForm = () => {
   };
 
   const handleSelectHubSpotContact = (contact: HubSpotContact) => {
+    const contactPrimaryStreet = contact.contactAddress1 || '';
+    const contactSecondaryStreet = contact.contactAddress || '';
+    const companyPrimaryStreet = contact.companyAddress1 || '';
+    const companySecondaryStreet = contact.companyAddress || '';
+
+    const preferredContactAddress =
+      formatAddressFromParts({
+        street: contactPrimaryStreet,
+        city: contact.contactCity,
+        state: contact.contactState,
+        zip: contact.contactZip
+      }) ||
+      formatAddressFromParts({
+        street: contactSecondaryStreet,
+        city: contact.contactCity,
+        state: contact.contactState,
+        zip: contact.contactZip
+      }) ||
+      contactPrimaryStreet.trim() ||
+      contactSecondaryStreet.trim();
+
+    const preferredCompanyAddress =
+      formatAddressFromParts({
+        street: companyPrimaryStreet,
+        city: contact.companyCity,
+        state: contact.companyState,
+        zip: contact.companyZip
+      }) ||
+      formatAddressFromParts({
+        street: companySecondaryStreet,
+        city: contact.companyCity,
+        state: contact.companyState,
+        zip: contact.companyZip
+      }) ||
+      companyPrimaryStreet.trim() ||
+      companySecondaryStreet.trim();
+
     setEquipmentData(prev => ({
       ...prev,
       contactName: `${contact.firstName} ${contact.lastName}`.trim(),
       email: contact.email,
       sitePhone: contact.phone || prev.sitePhone,
       companyName: contact.companyName || prev.companyName,
-      siteAddress: contact.contactAddress || contact.companyAddress || prev.siteAddress
+      siteAddress: preferredContactAddress || preferredCompanyAddress || prev.siteAddress
     }));
   };
 

--- a/src/lib/address.ts
+++ b/src/lib/address.ts
@@ -5,6 +5,13 @@ export interface ParsedAddressParts {
   zip: string
 }
 
+interface AddressPartsInput {
+  street?: string | null
+  city?: string | null
+  state?: string | null
+  zip?: string | null
+}
+
 const toUpperState = (value: string | undefined) =>
   value ? value.toUpperCase() : ''
 
@@ -140,4 +147,39 @@ export const parseAddressParts = (address: string): ParsedAddressParts => {
     state,
     zip
   }
+}
+
+export const formatAddressFromParts = ({
+  street,
+  city,
+  state,
+  zip
+}: AddressPartsInput): string => {
+  const normalizedStreet = street?.trim() ?? ''
+  const normalizedCity = city?.trim() ?? ''
+  const normalizedState = state?.trim()?.toUpperCase() ?? ''
+  const normalizedZip = zip?.trim() ?? ''
+
+  const lines: string[] = []
+
+  if (normalizedStreet) {
+    lines.push(normalizedStreet)
+  }
+
+  const cityStateZipSegments: string[] = []
+
+  if (normalizedCity) {
+    cityStateZipSegments.push(normalizedCity)
+  }
+
+  const stateZip = [normalizedState, normalizedZip].filter(Boolean).join(' ').trim()
+  if (stateZip) {
+    cityStateZipSegments.push(stateZip)
+  }
+
+  if (cityStateZipSegments.length > 0) {
+    lines.push(cityStateZipSegments.join(', '))
+  }
+
+  return lines.join('\n').trim()
 }

--- a/tests/useEquipmentForm.test.ts
+++ b/tests/useEquipmentForm.test.ts
@@ -1,0 +1,28 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useEquipmentForm } from '../src/hooks/useEquipmentForm'
+import { HubSpotContact } from '../src/services/hubspotService'
+
+describe('useEquipmentForm', () => {
+  it('uses contact address parts to populate siteAddress', () => {
+    const { result } = renderHook(() => useEquipmentForm())
+
+    const contact: HubSpotContact = {
+      id: '1',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      phone: '555-5555',
+      contactAddress1: '123 Main St',
+      contactCity: 'Portland',
+      contactState: 'or',
+      contactZip: '97205'
+    }
+
+    act(() => {
+      result.current.handleSelectHubSpotContact(contact)
+    })
+
+    expect(result.current.equipmentData.siteAddress).toBe('123 Main St\nPortland, OR 97205')
+  })
+})


### PR DESCRIPTION
## Summary
- prefer detailed HubSpot contact address fields when populating the equipment form
- add address formatter to compose city, state, and zip-friendly strings for reuse
- cover the new behavior with a dedicated useEquipmentForm unit test

## Testing
- npm run test -- tests/useEquipmentForm.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd6b38e2bc8321a84fec9212165a49