### PR TITLE
Add dedicated AI extractors for logistics and scope of work

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,13 @@ const App: React.FC = () => {
     closeHistory
   } = useModals()
 
+  const [extractorMode, setExtractorMode] = useState<'all' | 'logistics' | 'scope'>('all')
+
+  const handleOpenExtractor = (mode: 'all' | 'logistics' | 'scope') => {
+    setExtractorMode(mode)
+    openAIExtractor()
+  }
+
   // Hooks
   const sessionId = useSessionId()
   const { hasApiKey } = useApiKey()
@@ -138,23 +145,46 @@ const App: React.FC = () => {
     extractedLogisticsData: Partial<LogisticsData>
   ) => {
     console.log('handleAIExtraction called with:', { extractedEquipmentData, extractedLogisticsData })
-    
+
     if (extractedEquipmentData) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { projectDescription, ...rest } = extractedEquipmentData
-      const mappedEquipmentData = {
-        projectName: extractedEquipmentData.projectName || '',
-        companyName: extractedEquipmentData.companyName || '',
-        contactName: extractedEquipmentData.contactName || '',
-        siteAddress: extractedEquipmentData.projectAddress || extractedEquipmentData.siteAddress || '',
-        sitePhone: extractedEquipmentData.phone || extractedEquipmentData.sitePhone || '',
-        email: extractedEquipmentData.email || '',
-        scopeOfWork: extractedEquipmentData.scopeOfWork || ''
+      const mappedEquipmentData: Partial<EquipmentData> = {}
+
+      if (extractedEquipmentData.projectName) {
+        mappedEquipmentData.projectName = extractedEquipmentData.projectName
       }
-      console.log('Updating equipment data with:', mappedEquipmentData)
-      setEquipmentData(prev => ({ ...prev, ...mappedEquipmentData }))
+
+      if (extractedEquipmentData.companyName) {
+        mappedEquipmentData.companyName = extractedEquipmentData.companyName
+      }
+
+      if (extractedEquipmentData.contactName) {
+        mappedEquipmentData.contactName = extractedEquipmentData.contactName
+      }
+
+      const siteAddress = extractedEquipmentData.projectAddress || extractedEquipmentData.siteAddress
+      if (siteAddress) {
+        mappedEquipmentData.siteAddress = siteAddress
+      }
+
+      const sitePhone = extractedEquipmentData.phone || extractedEquipmentData.sitePhone
+      if (sitePhone) {
+        mappedEquipmentData.sitePhone = sitePhone
+      }
+
+      if (extractedEquipmentData.email) {
+        mappedEquipmentData.email = extractedEquipmentData.email
+      }
+
+      if (extractedEquipmentData.scopeOfWork) {
+        mappedEquipmentData.scopeOfWork = extractedEquipmentData.scopeOfWork
+      }
+
+      if (Object.keys(mappedEquipmentData).length > 0) {
+        console.log('Updating equipment data with:', mappedEquipmentData)
+        setEquipmentData(prev => ({ ...prev, ...mappedEquipmentData }))
+      }
     }
-    
+
     if (extractedLogisticsData) {
       const mappedLogisticsData: Partial<LogisticsData> = {}
       
@@ -287,7 +317,7 @@ const App: React.FC = () => {
           </button>
 
           <button
-            onClick={openAIExtractor}
+            onClick={() => handleOpenExtractor('all')}
             disabled={!hasApiKey}
             className={`flex items-center px-4 py-2 rounded-lg transition-colors ${
               hasApiKey
@@ -308,6 +338,8 @@ const App: React.FC = () => {
             onRequirementsChange={handleEquipmentRequirementsChange}
             onSelectContact={handleSelectHubSpotContact}
             onCopySiteAddress={copySiteAddressToPickup}
+            onOpenScopeExtractor={() => handleOpenExtractor('scope')}
+            canUseAI={hasApiKey}
             register={equipmentForm.register}
             errors={equipmentForm.formState.errors}
           />
@@ -323,6 +355,8 @@ const App: React.FC = () => {
             togglePieceSelection={togglePieceSelection}
             deleteSelectedPieces={deleteSelectedPieces}
             movePiece={movePiece}
+            onOpenLogisticsExtractor={() => handleOpenExtractor('logistics')}
+            canUseAI={hasApiKey}
             register={logisticsForm.register}
             errors={logisticsForm.formState.errors}
           />
@@ -463,6 +497,7 @@ const App: React.FC = () => {
           onClose={closeAIExtractor}
           onExtract={handleAIExtraction}
           sessionId={sessionId}
+          mode={extractorMode}
         />
 
         <QuoteSaveManager

--- a/src/components/EquipmentForm.tsx
+++ b/src/components/EquipmentForm.tsx
@@ -12,6 +12,8 @@ interface EquipmentFormProps {
   onRequirementsChange: (data: EquipmentRequirements) => void;
   onSelectContact: (contact: HubSpotContact) => void;
   onCopySiteAddress: () => boolean;
+  onOpenScopeExtractor: () => void;
+  canUseAI: boolean;
   register: UseFormRegister<EquipmentData>;
   errors: FieldErrors<EquipmentData>;
 }
@@ -22,6 +24,8 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({
   onRequirementsChange,
   onSelectContact,
   onCopySiteAddress,
+  onOpenScopeExtractor,
+  canUseAI,
   register,
   errors
 }) => {
@@ -36,6 +40,8 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({
         onChange={onFieldChange}
         onSelectContact={onSelectContact}
         onCopySiteAddress={onCopySiteAddress}
+        onOpenScopeExtractor={onOpenScopeExtractor}
+        canUseAI={canUseAI}
         register={register}
         errors={errors}
       />

--- a/src/components/LogisticsForm.tsx
+++ b/src/components/LogisticsForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Truck, Package, Plus, Minus, Trash2, ArrowUp, ArrowDown } from 'lucide-react'
+import { Truck, Package, Plus, Minus, Trash2, ArrowUp, ArrowDown, Bot } from 'lucide-react'
 import { UseFormRegister, FieldErrors } from 'react-hook-form'
 
 interface Piece {
@@ -42,6 +42,8 @@ interface LogisticsFormProps {
   togglePieceSelection: (pieceId: string) => void;
   deleteSelectedPieces: () => void;
   movePiece: (oldIndex: number, newIndex: number) => void;
+  onOpenLogisticsExtractor: () => void;
+  canUseAI: boolean;
   register: UseFormRegister<LogisticsData>;
   errors: FieldErrors<LogisticsData>;
 }
@@ -56,14 +58,31 @@ const LogisticsForm: React.FC<LogisticsFormProps> = ({
   togglePieceSelection,
   deleteSelectedPieces,
   movePiece,
+  onOpenLogisticsExtractor,
+  canUseAI,
   register,
   errors
 }) => {
   return (
     <div className="bg-gray-900 rounded-lg border-2 border-accent p-6">
-      <div className="flex items-center mb-6">
-        <Truck className="w-6 h-6 text-white mr-2" />
-        <h2 className="text-2xl font-bold text-white">Logistics Quote</h2>
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+        <div className="flex items-center">
+          <Truck className="w-6 h-6 text-white mr-2" />
+          <h2 className="text-2xl font-bold text-white">Logistics Quote</h2>
+        </div>
+        <button
+          type="button"
+          onClick={onOpenLogisticsExtractor}
+          disabled={!canUseAI}
+          className={`flex items-center justify-center px-3 py-2 rounded-lg text-sm transition-colors ${
+            canUseAI
+              ? 'bg-accent text-black hover:bg-green-400'
+              : 'bg-gray-700 text-gray-300 cursor-not-allowed'
+          }`}
+        >
+          <Bot className="w-4 h-4 mr-2" />
+          AI Logistics Extractor {canUseAI ? '✓' : '✗'}
+        </button>
       </div>
 
       <div className="space-y-6">

--- a/src/components/ProjectDetails.tsx
+++ b/src/components/ProjectDetails.tsx
@@ -9,7 +9,8 @@ import {
   X,
   Save,
   Copy,
-  CheckCircle
+  CheckCircle,
+  Bot
 } from 'lucide-react'
 import HubSpotContactSearch from './HubSpotContactSearch'
 import { HubSpotContact, HubSpotService } from '../services/hubspotService'
@@ -32,6 +33,8 @@ interface ProjectDetailsProps {
   onChange: (field: keyof ProjectDetailsData, value: string) => void
   onSelectContact: (contact: HubSpotContact) => void
   onCopySiteAddress: () => boolean
+  onOpenScopeExtractor: () => void
+  canUseAI: boolean
   register: UseFormRegister<ProjectDetailsData>
   errors: FieldErrors<ProjectDetailsData>
 }
@@ -41,6 +44,8 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({
   onChange,
   onSelectContact,
   onCopySiteAddress,
+  onOpenScopeExtractor,
+  canUseAI,
   register,
   errors
 }) => {
@@ -390,10 +395,25 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
-          <ClipboardList className="w-4 h-4 inline mr-1" />
-          Scope of Work
-        </label>
+        <div className="flex items-center justify-between mb-2">
+          <label className="block text-sm font-medium text-white">
+            <ClipboardList className="w-4 h-4 inline mr-1" />
+            Scope of Work
+          </label>
+          <button
+            type="button"
+            onClick={onOpenScopeExtractor}
+            disabled={!canUseAI}
+            className={`flex items-center px-2 py-1 rounded-lg text-xs transition-colors border ${
+              canUseAI
+                ? 'bg-accent text-black border-accent hover:bg-green-400'
+                : 'bg-gray-700 text-gray-300 border-gray-600 cursor-not-allowed'
+            }`}
+          >
+            <Bot className="w-3 h-3 mr-1" />
+            Extract Scope {canUseAI ? '✓' : '✗'}
+          </button>
+        </div>
         {(() => {
           const field = register('scopeOfWork')
           return (


### PR DESCRIPTION
## Summary
- add extractor mode state so the AI modal can be opened in all, logistics-only, or scope-only modes
- update the AI extractor modal to adjust messaging and returned data based on the selected mode
- surface new logistics and scope extractor buttons within their respective form sections while keeping the global extractor button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6d38cf60832187485e5707d982d4