### PR TITLE
Avoid duplicating city/state information in formatted addresses

### DIFF
--- a/src/lib/address.ts
+++ b/src/lib/address.ts
@@ -166,13 +166,40 @@ export const formatAddressFromParts = ({
     lines.push(normalizedStreet)
   }
 
+  const streetParts = normalizedStreet ? parseAddressParts(normalizedStreet) : createEmpty()
+
+  const streetCity = streetParts.city.trim().toLowerCase()
+  const streetState = streetParts.state.trim().toUpperCase()
+  const streetZip = streetParts.zip.trim()
+
+  const normalizedCityLower = normalizedCity.toLowerCase()
+
+  const streetAlreadyHasCity =
+    Boolean(normalizedCity) && streetCity === normalizedCityLower
+
+  const streetAlreadyHasState =
+    Boolean(normalizedState) && streetState === normalizedState
+
+  const streetAlreadyHasZip = Boolean(normalizedZip) && streetZip === normalizedZip
+
   const cityStateZipSegments: string[] = []
 
-  if (normalizedCity) {
+  if (normalizedCity && !streetAlreadyHasCity) {
     cityStateZipSegments.push(normalizedCity)
   }
 
-  const stateZip = [normalizedState, normalizedZip].filter(Boolean).join(' ').trim()
+  const stateZipParts: string[] = []
+
+  if (normalizedState && !streetAlreadyHasState) {
+    stateZipParts.push(normalizedState)
+  }
+
+  if (normalizedZip && !streetAlreadyHasZip) {
+    stateZipParts.push(normalizedZip)
+  }
+
+  const stateZip = stateZipParts.join(' ').trim()
+
   if (stateZip) {
     cityStateZipSegments.push(stateZip)
   }


### PR DESCRIPTION
## Summary
- parse the provided street line when formatting addresses to detect existing city/state/zip data
- append only the missing city/state/zip components so HubSpot-provided addresses are not duplicated

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e6bc49c9008321b0e076ae17c11267